### PR TITLE
Only display loading if it is initial (i.e. no data exists)

### DIFF
--- a/projects/bp-gallery/src/views/gallery/common/PictureScrollGrid.tsx
+++ b/projects/bp-gallery/src/views/gallery/common/PictureScrollGrid.tsx
@@ -52,7 +52,7 @@ const PictureScrollGrid = ({
 
   if (error) {
     return <QueryErrorDisplay error={error} />;
-  } else if (loading) {
+  } else if (loading && !data?.pictures) {
     return <Loading />;
   } else if (data?.pictures?.length) {
     return <PictureGrid pictures={data.pictures as Picture[]} hashBase={hashbase} />;


### PR DESCRIPTION
Context: if we fetch new pictures in the picture-scroll-grid (as the user scrolled to the bottom) a new query is sent (and there is new loading status). That could result in a reset of the scroll position of top (as the PictureScrollGrid) is completely re-rendered. Now we only show the loading component when the _initial_ picture-query is sent in order to prevent scroll-position-jumps.