### PR TITLE
Update Strapi to 4.1.12

### DIFF
--- a/projects/bp-strapi/package.json
+++ b/projects/bp-strapi/package.json
@@ -18,11 +18,11 @@
     "supertest": "^6.2.3"
   },
   "dependencies": {
-    "@strapi/plugin-graphql": "4.1.9",
-    "@strapi/plugin-i18n": "4.1.9",
-    "@strapi/plugin-sentry": "^4.1.9",
-    "@strapi/plugin-users-permissions": "4.1.9",
-    "@strapi/strapi": "4.1.9",
+    "@strapi/plugin-graphql": "4.1.12",
+    "@strapi/plugin-i18n": "4.1.12",
+    "@strapi/plugin-sentry": "4.1.12",
+    "@strapi/plugin-users-permissions": "4.1.12",
+    "@strapi/strapi": "4.1.12",
     "cross-env": "^7.0.3",
     "pg": "8.6.0",
     "xlsx": "^0.18.5"

--- a/projects/bp-strapi/yarn.lock
+++ b/projects/bp-strapi/yarn.lock
@@ -1824,6 +1824,16 @@
   resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz#a3031eb54129f2c66b2753f8404266ec7bf67f0a"
   integrity sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==
 
+"@rushstack/ts-command-line@^4.7.7":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.11.0.tgz#4cd3b9f59b41aed600042936260fdaa55ca0184d"
+  integrity sha512-ptG9L0mjvJ5QtK11GsAFY+jGfsnqHDS6CY6Yw1xT7a9bhjfNYnf6UPwjV+pF6UgiucfNcMDNW9lkDLxvZKKxMg==
+  dependencies:
+    "@types/argparse" "1.0.38"
+    argparse "~1.0.9"
+    colors "~1.2.1"
+    string-argv "~0.3.1"
+
 "@sentry/core@6.19.6":
   version "6.19.6"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.19.6.tgz#7d4649d0148b5d0be1358ab02e2f869bf7363e9a"
@@ -1835,17 +1845,6 @@
     "@sentry/utils" "6.19.6"
     tslib "^1.9.3"
 
-"@sentry/core@6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.3.0.tgz#3b8db24918a00c0b77f1663fc6d9be925f66bb3e"
-  integrity sha512-voot/lJ9gRXB6bx6tVqbEbD6jOd4Sx6Rfmm6pzfpom9C0q+fjIZTatTLq8GdXj8DzxaH1MBDSwtaq/eC3NqYpA==
-  dependencies:
-    "@sentry/hub" "6.3.0"
-    "@sentry/minimal" "6.3.0"
-    "@sentry/types" "6.3.0"
-    "@sentry/utils" "6.3.0"
-    tslib "^1.9.3"
-
 "@sentry/hub@6.19.6":
   version "6.19.6"
   resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.19.6.tgz#ada83ceca0827c49534edfaba018221bc1eb75e1"
@@ -1855,15 +1854,6 @@
     "@sentry/utils" "6.19.6"
     tslib "^1.9.3"
 
-"@sentry/hub@6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.3.0.tgz#4225b3b0f31fe47f24d80753b257a4b57de5d651"
-  integrity sha512-lAnW3Om66t9IR+t1wya1NpOF9lGbvYG6Ca8wxJJGJ1t2PxKwyxpZKzRx0q8M1QFhlZ5cETCzxmM7lBEZ4QVCBg==
-  dependencies:
-    "@sentry/types" "6.3.0"
-    "@sentry/utils" "6.3.0"
-    tslib "^1.9.3"
-
 "@sentry/minimal@6.19.6":
   version "6.19.6"
   resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.19.6.tgz#b6cced3708e25d322039e68ebdf8fadfa445bf7d"
@@ -1871,15 +1861,6 @@
   dependencies:
     "@sentry/hub" "6.19.6"
     "@sentry/types" "6.19.6"
-    tslib "^1.9.3"
-
-"@sentry/minimal@6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.3.0.tgz#e64d87c92a4676a11168672a96589f46985f2b22"
-  integrity sha512-ZdPUwdPQkaKroy67NkwQRqmnfKyd/C1OyouM9IqYKyBjAInjOijwwc/Rd91PMHalvCOGfp1scNZYbZ+YFs/qQQ==
-  dependencies:
-    "@sentry/hub" "6.3.0"
-    "@sentry/types" "6.3.0"
     tslib "^1.9.3"
 
 "@sentry/node@6.19.6":
@@ -1896,41 +1877,10 @@
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/node@6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.3.0.tgz#8d55f32930d531b9a2a3b594754392925b1e3816"
-  integrity sha512-n3RemuJsMpSbrIopJ2TxeECwQy/Dvho59SePAVQzK0s6dpG3Ak6YWQSh1XESbFbgLi4KzkbMdeBgznmmEbZPgg==
-  dependencies:
-    "@sentry/core" "6.3.0"
-    "@sentry/hub" "6.3.0"
-    "@sentry/tracing" "6.3.0"
-    "@sentry/types" "6.3.0"
-    "@sentry/utils" "6.3.0"
-    cookie "^0.4.1"
-    https-proxy-agent "^5.0.0"
-    lru_map "^0.3.3"
-    tslib "^1.9.3"
-
-"@sentry/tracing@6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.3.0.tgz#5da2ce67bb5f9cf4f3aa9b6dff06089478f0c501"
-  integrity sha512-3UNGgQOrDKBoDqLc4vt+0n27Zv3lbNEoCbBydq4IvGfuYq7ozWMsaTcelsotMsd4ckDuOEh8V/nJTqrDjvL76g==
-  dependencies:
-    "@sentry/hub" "6.3.0"
-    "@sentry/minimal" "6.3.0"
-    "@sentry/types" "6.3.0"
-    "@sentry/utils" "6.3.0"
-    tslib "^1.9.3"
-
 "@sentry/types@6.19.6":
   version "6.19.6"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.19.6.tgz#70513f9dca05d23d7ab9c2a6cb08d4db6763ca67"
   integrity sha512-QH34LMJidEUPZK78l+Frt3AaVFJhEmIi05Zf8WHd9/iTt+OqvCHBgq49DDr1FWFqyYWm/QgW/3bIoikFpfsXyQ==
-
-"@sentry/types@6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.3.0.tgz#919cc1870f34b7126546c77e3c695052795d3add"
-  integrity sha512-xWyCYDmFPjS5ex60kxOOHbHEs4vs00qHbm0iShQfjl4OSg9S2azkcWofDmX8Xbn0FSOUXgdPCjNJW1B0bPVhCA==
 
 "@sentry/utils@6.19.6":
   version "6.19.6"
@@ -1938,14 +1888,6 @@
   integrity sha512-fAMWcsguL0632eWrROp/vhPgI7sBj/JROWVPzpabwVkm9z3m1rQm6iLFn4qfkZL8Ozy6NVZPXOQ7EXmeU24byg==
   dependencies:
     "@sentry/types" "6.19.6"
-    tslib "^1.9.3"
-
-"@sentry/utils@6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.3.0.tgz#e28645b6d4acd03a478e58bfe112ea02f81e94a0"
-  integrity sha512-NZzw4oLelgvCsVBG2e+ZtFtaBvgA7rZYtcGFbZTphhAlYoJ6JMCQUzYk0iwJK79yR1quh510x4UE0jynvvToWg==
-  dependencies:
-    "@sentry/types" "6.3.0"
     tslib "^1.9.3"
 
 "@simov/deep-extend@^1.0.0":
@@ -1993,10 +1935,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@strapi/admin@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/admin/-/admin-4.1.9.tgz#877422492f1c8f7351b58644db92a1814af47eba"
-  integrity sha512-wCfvIaaMro42cllfQSj4xM/UpI5u+ZpS7HRxVti0KkyonE+9ZcztCQ7idEr54W0P4Pa/SPRhahuoV3NZSyXOCw==
+"@strapi/admin@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/admin/-/admin-4.1.12.tgz#fc9aa42c31df5e9a6da862ed05fedf43786488cf"
+  integrity sha512-AD5VZ/q68IXlYOLmO7CSafxIRkdeWJLDdjejVXWHVSu5zg/9JXMRlHOmsUz51P7nk1VhW+zo2xlrYrVLmbQLRg==
   dependencies:
     "@babel/core" "7.16.7"
     "@babel/plugin-transform-runtime" "7.16.7"
@@ -2011,11 +1953,11 @@
     "@fortawesome/free-brands-svg-icons" "^5.15.3"
     "@fortawesome/free-solid-svg-icons" "^5.15.3"
     "@fortawesome/react-fontawesome" "^0.1.14"
-    "@strapi/babel-plugin-switch-ee-ce" "4.1.9"
-    "@strapi/design-system" "1.1.0"
-    "@strapi/helper-plugin" "4.1.9"
-    "@strapi/icons" "1.1.0"
-    "@strapi/utils" "4.1.9"
+    "@strapi/babel-plugin-switch-ee-ce" "4.1.12"
+    "@strapi/design-system" "1.1.1"
+    "@strapi/helper-plugin" "4.1.12"
+    "@strapi/icons" "1.1.1"
+    "@strapi/utils" "4.1.12"
     axios "0.24.0"
     babel-loader "8.2.3"
     babel-plugin-styled-components "2.0.2"
@@ -2094,38 +2036,38 @@
     webpackbar "5.0.0-3"
     yup "^0.32.9"
 
-"@strapi/babel-plugin-switch-ee-ce@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/babel-plugin-switch-ee-ce/-/babel-plugin-switch-ee-ce-4.1.9.tgz#390c64b8865cc6b439f3113b62ec5e48b488640e"
-  integrity sha512-Z4LPLPaowzlfqmttIxHuQmGGxXlEXJh+H7y0YkDtsEZmyVQBBBTBHUTBLPyHWn38gHJZKFA7/eph5KEvzKLGEg==
+"@strapi/babel-plugin-switch-ee-ce@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/babel-plugin-switch-ee-ce/-/babel-plugin-switch-ee-ce-4.1.12.tgz#c39b65016b72d909f217d563c0e5af431064f7aa"
+  integrity sha512-f7WRfyW3AfhhHE1l9NRSVJLLipl/bQAarlmxYAq8muELJ1SbhMnTelPaoHceb+GoJQgSnE576WKqAO14hsf7wg==
 
-"@strapi/database@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/database/-/database-4.1.9.tgz#356da9860ccb3a8cfc884368f4fab5ba7de1ad47"
-  integrity sha512-P1Od8GJ+sY8Z1XQGCOWs9qBXnzHG1xs2FjxvHrLGQZR333rN7DAyrp4mECxqyQ4B+kGB6DZ45KPVb9yybqLfQA==
+"@strapi/database@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/database/-/database-4.1.12.tgz#90bc97ebf4be2df42cac7bb932bba446591c1ec4"
+  integrity sha512-pEf+A+rEbzhjNQIBkE5Z6iG5yaq4Mw/EUuXoVi/YdE1Qqz84U5nT7crpjScvLZD/NJDtO+m2QwQzrMvJZbryGw==
   dependencies:
     date-fns "2.22.1"
     debug "4.3.1"
     fs-extra "10.0.0"
     knex "1.0.4"
     lodash "4.17.21"
-    umzug "2.3.0"
+    umzug "3.1.1"
 
-"@strapi/design-system@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@strapi/design-system/-/design-system-1.1.0.tgz#da40d68fa0493d886c45e829c253d0e2ecc8d2ca"
-  integrity sha512-XXd2q4Ug+bM7z0TK7G/deQPyl4jV7odW2JwgXp5WAZw7pt4JDkOs/2FnpRKXvNj3USvIoYI6QSSrcO124YyUgA==
+"@strapi/design-system@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@strapi/design-system/-/design-system-1.1.1.tgz#87efc79a0cb0f8b74fd36924bc4089c91928f946"
+  integrity sha512-yM67ASyhtJqOSNPYiOQIG9qxsd9ceZ/00Yf0be5dArlgnhm/byQLnrWunq4L2mnhBGI1S6EjXjRzML/7NL5VDQ==
   dependencies:
     "@internationalized/number" "^3.0.2"
     compute-scroll-into-view "^1.0.17"
     prop-types "^15.7.2"
 
-"@strapi/generate-new@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/generate-new/-/generate-new-4.1.9.tgz#e0c452861978de22b780636a562a9154d2442144"
-  integrity sha512-jx6U58vtcuYARRgY1IP5On3zPGcG3qmNcfDliqPrxldkmQ001aObOZK8yoICqY3ly1AP0y1K9ACOsk2ZGCRHIQ==
+"@strapi/generate-new@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/generate-new/-/generate-new-4.1.12.tgz#58a5d341be9885c5ddc0084da5fab123b2eddc10"
+  integrity sha512-tn2piYjSy5uLcaxIsOteDRfBTXfX0XA5jO+mIMMML11u052NQ+NyCoMy7H9znTrAe7mgSHBFUw2AicNTBllZyA==
   dependencies:
-    "@sentry/node" "6.3.0"
+    "@sentry/node" "6.19.6"
     chalk "^4.1.1"
     execa "^1.0.0"
     fs-extra "10.0.0"
@@ -2137,23 +2079,23 @@
     tar "6.1.11"
     uuid "^3.3.2"
 
-"@strapi/generators@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/generators/-/generators-4.1.9.tgz#ee04089537b4dbe7371994fc17568df47ed23127"
-  integrity sha512-y0+Q6cpTVcm/qRla0mOj3j54/8IGSW9Nu43RtNVNbWipY/OLNSWh/PLLCi52GyseCUnnICczgMi5R40WQCV9Zw==
+"@strapi/generators@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/generators/-/generators-4.1.12.tgz#1a3f59a0c32a49bad843f44dab5d2025e3c7076f"
+  integrity sha512-mKhC+9M+swAr+bbAUMrCHAewOY5zr3ZRrcVhvQa4MBbYLn7dfb+g5i25tO+AzoDUI8j3bxP+39I7d7qpqsJS/A==
   dependencies:
     "@sindresorhus/slugify" "1.1.0"
-    "@strapi/utils" "4.1.9"
+    "@strapi/utils" "4.1.12"
     chalk "4.1.2"
     fs-extra "10.0.0"
     node-plop "0.26.3"
     plop "2.7.6"
     pluralize "8.0.0"
 
-"@strapi/helper-plugin@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/helper-plugin/-/helper-plugin-4.1.9.tgz#699b59ee8af61309b76e9574e909f206acb58ee7"
-  integrity sha512-R0R84D38/zVmH4glDeuPwo0e/yd2AAwcvHRKCV2oxJJnMwGlJw252UD7nYg4XdxOdCu0YB2tft0oI0wLSvvLTQ==
+"@strapi/helper-plugin@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/helper-plugin/-/helper-plugin-4.1.12.tgz#889b8f39ddbd66b9c08b1578b05f38bbc7a27ae5"
+  integrity sha512-R3QKpjhvwB4ZuJlYzkmvDAuZ+agmrc4Yy/eguHamCTdLpyls/DFNwkRomfjkrm9+jKM0tkwEkflmXARHw2c0Cg==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.15.2"
     "@fortawesome/fontawesome-svg-core" "^1.2.35"
@@ -2177,39 +2119,39 @@
     styled-components "5.3.3"
     whatwg-fetch "^3.6.2"
 
-"@strapi/icons@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@strapi/icons/-/icons-1.1.0.tgz#ce146ee6ce2098f97b15263aa502367945961f8a"
-  integrity sha512-SPrkNGYv12T9gIef3Dv/OmHKIp1RR0AazVXazKYidkrjDVnMR4UTQVO4Q4mxK6Qxe2JmXAk7tTTu+7LCVWxkNg==
+"@strapi/icons@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@strapi/icons/-/icons-1.1.1.tgz#dd3866ac94866286011d3a71e2dc287cb8c7828e"
+  integrity sha512-TaVVZWB8xWksm5ONthECi2bNtm643Maj+Yr3qtEfaNGPuoRWbNkiXQROrMZiDLUtmaUgJtQj4Wr41bZJxgQ/4g==
   dependencies:
     rimraf "^3.0.2"
 
-"@strapi/logger@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/logger/-/logger-4.1.9.tgz#ba959b081c9241eae2270f163d225d8d22a6364a"
-  integrity sha512-CODcO6h4cZG8ONbj4E3ZjMnn8WzL49CsCj2ACdFLVFjyKTiotJOX9Kzv2PSx6uSFD+hdJwwQe1q5eMZDaimiMA==
+"@strapi/logger@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/logger/-/logger-4.1.12.tgz#49ec3f9daf00d6b6109c73708574cf0fa7d5d341"
+  integrity sha512-smexW6O176Sg/z8qiOarXIS3wuCp2QanFCkb1bMKzF3+K8k092etQvDf48xas05DujaC0rjcds1v88g6+eIwBg==
   dependencies:
     lodash "4.17.21"
     winston "3.3.3"
 
-"@strapi/plugin-content-manager@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-content-manager/-/plugin-content-manager-4.1.9.tgz#01f4dc700100e8a7ceb8c77b4e164a72e66038e9"
-  integrity sha512-yjF/S4HB9euSeI8jhc15NgL999S9nCjxuITiQPqQz+u7FeE4g3+pE8ATMdZU/D9+tcH/QalTZWQSylOpkucqsA==
+"@strapi/plugin-content-manager@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-content-manager/-/plugin-content-manager-4.1.12.tgz#db687b9d22fc797f15cd7060a484cabb0cb2f749"
+  integrity sha512-sg9KerOuMOPpnv9fXl8KJ1GtW6xfBQ+w9yrlL6FFSM9eOI0kFDEcFQajtotaDE+tAAe7rJ/v5cts1EDiAJOZkw==
   dependencies:
     "@sindresorhus/slugify" "1.1.0"
-    "@strapi/utils" "4.1.9"
+    "@strapi/utils" "4.1.12"
     lodash "4.17.21"
 
-"@strapi/plugin-content-type-builder@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.1.9.tgz#f02c594b6f03a2babad187c923ace7a20494f6be"
-  integrity sha512-zVU2GA9ZIUEopMUuosYQJDixZ1N/m7z/rexEIVqNSsC0xGtkXSjrkIo8Fffvw59tPp/rBYP+AG6G+ORVH6Fx6w==
+"@strapi/plugin-content-type-builder@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.1.12.tgz#dfa23e95ef342f14234ec5c830786803cc1f466c"
+  integrity sha512-ZYQxh4MqT+X5w+xIBxtKQh7jQMOS3pXNGzo++kUuytXL8m0YgngBgpgwr2VmXXZ5/A5JIL0MjcBxa0dXsg2Row==
   dependencies:
     "@sindresorhus/slugify" "1.1.0"
-    "@strapi/generators" "4.1.9"
-    "@strapi/helper-plugin" "4.1.9"
-    "@strapi/utils" "4.1.9"
+    "@strapi/generators" "4.1.12"
+    "@strapi/helper-plugin" "4.1.12"
+    "@strapi/utils" "4.1.12"
     fs-extra "10.0.0"
     lodash "4.17.21"
     pluralize "^8.0.0"
@@ -2223,24 +2165,24 @@
     reselect "^4.0.0"
     yup "^0.32.9"
 
-"@strapi/plugin-email@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-email/-/plugin-email-4.1.9.tgz#83680c7f0ad24dadc74027b33bb1e77123a03bcf"
-  integrity sha512-YRyonMSNgtUGJBjXYPsqLL+x9O0ecYEQfphlfTnmVqLvYOCfoLZs5hKr1xtX/Mqscm2jruh1jgPwTQOf/W0CdQ==
+"@strapi/plugin-email@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-email/-/plugin-email-4.1.12.tgz#b1d59de7a6141dcff118ca0da97ce842c68d0c99"
+  integrity sha512-yDI+YM/WioyFgW7ZsfX+nAcXqRmNW7IuKFw/zIlOatIPdsd/O+KJ4iNHGHF3rjAY+AUnkNXX0u9c5Qc7Dj5GTQ==
   dependencies:
-    "@strapi/provider-email-sendmail" "4.1.9"
-    "@strapi/utils" "4.1.9"
+    "@strapi/provider-email-sendmail" "4.1.12"
+    "@strapi/utils" "4.1.12"
     lodash "4.17.21"
 
-"@strapi/plugin-graphql@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-graphql/-/plugin-graphql-4.1.9.tgz#e641d674ca6d338165c0db4c8f97893c5fead9de"
-  integrity sha512-Pfh9zbVJh6asvhG18uRM/4JhgtNpz1QpEljI7kSupGPVV9UtCf5+JegIzKdkiM8P1hgqkQN9fbkMfuuAH3pwjQ==
+"@strapi/plugin-graphql@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-graphql/-/plugin-graphql-4.1.12.tgz#b5548c18ee083f73822294371c858dba975f6018"
+  integrity sha512-xG2N7wFtE7AUpx8v/BwJ0Vw+48iMjlHpT+h6NQLCSkLWCGV4nCYWt35Ck528lmomiYNbZcs/wH30e2MfpaZQUg==
   dependencies:
     "@apollo/federation" "^0.28.0"
     "@graphql-tools/schema" "8.1.2"
     "@graphql-tools/utils" "^8.0.2"
-    "@strapi/utils" "4.1.9"
+    "@strapi/utils" "4.1.12"
     apollo-server-core "3.1.2"
     apollo-server-koa "3.1.2"
     glob "^7.1.7"
@@ -2257,29 +2199,29 @@
     pluralize "^8.0.0"
     subscriptions-transport-ws "0.9.19"
 
-"@strapi/plugin-i18n@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-i18n/-/plugin-i18n-4.1.9.tgz#d3783d834bbc3d92a5391c8bd29cde7b29b75c0e"
-  integrity sha512-b4AakKldXdwMt0ug4cBOUAJsVSr6OvR6uTHoY9hfegfOv4UobGPap6usmJYk27bptwGEYeuM35vRfEsBzvSe4g==
+"@strapi/plugin-i18n@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-i18n/-/plugin-i18n-4.1.12.tgz#e6e7aae8a12724e2a67fbc02af9b53cb1ea4fc5e"
+  integrity sha512-RvCGJRQnkLJp0yKD0g3xYxpxQ5EcBccsgALeke86Jlz86Qt8/IIn2NEWoLWmXSumipCzoG23WW/YDxXfQU5EyQ==
   dependencies:
-    "@strapi/utils" "4.1.9"
+    "@strapi/utils" "4.1.12"
     lodash "4.17.21"
 
-"@strapi/plugin-sentry@^4.1.9":
+"@strapi/plugin-sentry@4.1.12":
   version "4.1.12"
   resolved "https://registry.yarnpkg.com/@strapi/plugin-sentry/-/plugin-sentry-4.1.12.tgz#c36994d6f9cd27e2d2a7c6cecb0ff94e31c8292f"
   integrity sha512-o/3mZ6DJxYB6Ed6vpvDZP5RQR9PkvCO88Nuo1SK+9+xxawfVZM/C+QUglYqzWDUJEUglY9sm/6hbwfpvP1XDDQ==
   dependencies:
     "@sentry/node" "6.19.6"
 
-"@strapi/plugin-upload@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-upload/-/plugin-upload-4.1.9.tgz#1db42e6fc8f8fe707a83fe85c73af70f1b8b9d12"
-  integrity sha512-CVN1WMDqhsX/3I0+tYZQWBpwXlqkE5KRCU13YqVlKLbQjERSRbS6/m0rUOvsp2Q992cg6AvHPyDf6ztRkavR9w==
+"@strapi/plugin-upload@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-upload/-/plugin-upload-4.1.12.tgz#d98e5938a815c082bc20fc7d9a07124c1958e4d9"
+  integrity sha512-flUqhqKo0Jzz99PTSlNIE+hALA2+zv6WWIn7xdHLh41Bn6N8odBIZXiJseA/CNNYi22YRb9+Gp5k7QSPjchRyg==
   dependencies:
-    "@strapi/helper-plugin" "4.1.9"
-    "@strapi/provider-upload-local" "4.1.9"
-    "@strapi/utils" "4.1.9"
+    "@strapi/helper-plugin" "4.1.12"
+    "@strapi/provider-upload-local" "4.1.12"
+    "@strapi/utils" "4.1.12"
     byte-size "7.0.1"
     cropperjs "1.5.11"
     fs-extra "10.0.0"
@@ -2287,6 +2229,7 @@
     koa-range "0.3.0"
     koa-static "5.0.0"
     lodash "4.17.21"
+    mime-types "2.1.35"
     react "^17.0.2"
     react-copy-to-clipboard "^5.0.3"
     react-dom "^17.0.2"
@@ -2296,13 +2239,13 @@
     react-router-dom "5.2.0"
     sharp "0.30.4"
 
-"@strapi/plugin-users-permissions@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-users-permissions/-/plugin-users-permissions-4.1.9.tgz#24c6e66c47f8d70ffa9298eafbdeb62ae3c84207"
-  integrity sha512-+4+EFjbgNVrQOVu9i4ypYKrH0HMAaG0yp4AN96kKUkvJs6rwo2qi3NCS9Ylvwhvz7gtkOIWowiT7kVtUr6TgSg==
+"@strapi/plugin-users-permissions@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-users-permissions/-/plugin-users-permissions-4.1.12.tgz#9d48fddd0744691ff73c10b3af569e32fadd9ec2"
+  integrity sha512-fY7f6gjQ7UKDyVL5TK0PPTitk0aJuUXknbiLA7VsBaDUiAma+3MV5CtX06SlEHRjsPn3PJRG0fKctKVlKcEpHg==
   dependencies:
-    "@strapi/helper-plugin" "4.1.9"
-    "@strapi/utils" "4.1.9"
+    "@strapi/helper-plugin" "4.1.12"
+    "@strapi/utils" "4.1.12"
     bcryptjs "2.4.3"
     grant-koa "5.4.8"
     jsonwebtoken "^8.1.0"
@@ -2319,39 +2262,39 @@
     request "^2.83.0"
     url-join "4.0.1"
 
-"@strapi/provider-email-sendmail@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.1.9.tgz#ca1f1e4eeb49b37ceb8cb1fcb1b2f3f8a073abf4"
-  integrity sha512-ZA9uAcEY3X1PiwU7MDZfop8v7Cs0fbvCIozMmlR7t8zgVhWAc6pIAgKDl+xiDHA4aJO+i3dCq4uNomQISDmjZg==
+"@strapi/provider-email-sendmail@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.1.12.tgz#5ee1dad3f10720e603f7949fff5cc2cfa07c3bea"
+  integrity sha512-2FJxSH6FviIUDtAcaCZxHUVt2Ywgirv16HdWjvKEAwkt0ZgJ4MQvLJsN+zIEiN5WgtmtqaXolefXLHbskc72eA==
   dependencies:
-    "@strapi/utils" "4.1.9"
+    "@strapi/utils" "4.1.12"
     sendmail "^1.6.1"
 
-"@strapi/provider-upload-local@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/provider-upload-local/-/provider-upload-local-4.1.9.tgz#ba8cf3c3b8f9bebe21ab14119c7e297b27f4a7b8"
-  integrity sha512-FIGspmMQMe5NJWoMphTQclENqSrNiWITB2NRO7mfXpdFl3RvRWYyftLxmUcI/CDbRMP5FwPE1AFfzoxSl50vCQ==
+"@strapi/provider-upload-local@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/provider-upload-local/-/provider-upload-local-4.1.12.tgz#c88f55a1125ca02927bd09810c57a6482713f151"
+  integrity sha512-G4/UcCBPI68UZjtmItUs8m0tMRx9DGqm8sPG0bB4ClRI60nmu5fGoIxzh2TOBwJPo5oHBSMC1L35EO9K3pbTng==
   dependencies:
-    "@strapi/utils" "4.1.9"
+    "@strapi/utils" "4.1.12"
     fs-extra "10.0.0"
 
-"@strapi/strapi@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/strapi/-/strapi-4.1.9.tgz#f191b11a5022357c9d9468f8a034e5c3e884b0d2"
-  integrity sha512-bsdJsJh2t2gCMdn0X3/1D8ORG3q2F4gAkrk3xpzBDN7bjd85ahANtp/h/+z3hoP76eBdSswhVgTesWf/hrzsrw==
+"@strapi/strapi@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/strapi/-/strapi-4.1.12.tgz#57dc568efedd868873615eb6a3afbac8d0067ec2"
+  integrity sha512-vjGE5r0r6wtwA4ixcIZTc2dLRqkPZ22hxM7naUw3lUXynK3GlyyDMASJUMTXRAcxsF/eNrZz2779XgpyPdO8bA==
   dependencies:
     "@koa/cors" "3.1.0"
     "@koa/router" "10.1.1"
-    "@strapi/admin" "4.1.9"
-    "@strapi/database" "4.1.9"
-    "@strapi/generate-new" "4.1.9"
-    "@strapi/generators" "4.1.9"
-    "@strapi/logger" "4.1.9"
-    "@strapi/plugin-content-manager" "4.1.9"
-    "@strapi/plugin-content-type-builder" "4.1.9"
-    "@strapi/plugin-email" "4.1.9"
-    "@strapi/plugin-upload" "4.1.9"
-    "@strapi/utils" "4.1.9"
+    "@strapi/admin" "4.1.12"
+    "@strapi/database" "4.1.12"
+    "@strapi/generate-new" "4.1.12"
+    "@strapi/generators" "4.1.12"
+    "@strapi/logger" "4.1.12"
+    "@strapi/plugin-content-manager" "4.1.12"
+    "@strapi/plugin-content-type-builder" "4.1.12"
+    "@strapi/plugin-email" "4.1.12"
+    "@strapi/plugin-upload" "4.1.12"
+    "@strapi/utils" "4.1.12"
     bcryptjs "2.4.3"
     boxen "5.1.2"
     chalk "4.1.2"
@@ -2379,6 +2322,7 @@
     koa-session "6.2.0"
     koa-static "5.0.0"
     lodash "4.17.21"
+    mime-types "2.1.35"
     node-fetch "2.6.7"
     node-machine-id "1.1.12"
     node-schedule "2.0.0"
@@ -2391,10 +2335,10 @@
     statuses "2.0.1"
     uuid "^3.3.2"
 
-"@strapi/utils@4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@strapi/utils/-/utils-4.1.9.tgz#1f71bac3ec997fbf18d0fea8890401c66415c733"
-  integrity sha512-A1yag68PBa4Dee6pWoYWLFv1N7BXyfOEf0LfoNKGpRfLoo7LizPyduT4k/LxtuUqj6SHUKM7YUAOToMnbpW/7Q==
+"@strapi/utils@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@strapi/utils/-/utils-4.1.12.tgz#25f11e1080a13b04cdae76f74543a4e898d7063e"
+  integrity sha512-s5qI3+5KOfaksl4DvY28F68KyfmJz9oeIIMEbGX03CtnXerejws1gDKVIuyxHNXsQL1MkgG0Ejsyl4l4Pb04eA==
   dependencies:
     "@sindresorhus/slugify" "1.1.0"
     date-fns "2.24.0"
@@ -2420,6 +2364,11 @@
   integrity sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==
   dependencies:
     "@types/node" "*"
+
+"@types/argparse@1.0.38":
+  version "1.0.38"
+  resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.38.tgz#a81fd8606d481f873a3800c6ebae4f1d768a56a9"
+  integrity sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==
 
 "@types/babel__core@^7.1.14":
   version "7.1.19"
@@ -3379,7 +3328,7 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-argparse@^1.0.7:
+argparse@^1.0.7, argparse@~1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
@@ -3739,7 +3688,7 @@ bluebird@3.5.1:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
   integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
 
-bluebird@^3.5.0, bluebird@^3.7.2:
+bluebird@^3.5.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -4504,6 +4453,11 @@ colors@1.4.0, colors@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
+colors@~1.2.1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.5.tgz#89c7ad9a374bc030df8013241f68136ed8835afc"
+  integrity sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==
 
 colorspace@1.1.x:
   version "1.1.4"
@@ -6136,6 +6090,14 @@ fs-extra@10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-jetpack@^4.1.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/fs-jetpack/-/fs-jetpack-4.3.1.tgz#cdfd4b64e6bfdec7c7dc55c76b39efaa7853bb20"
+  integrity sha512-dbeOK84F6BiQzk2yqqCVwCPWTxAvVGJ3fMQc6E2wuEohS28mR6yHngbrKuVCK1KHRx/ccByDylqu4H5PCP2urQ==
+  dependencies:
+    minimatch "^3.0.2"
+    rimraf "^2.6.3"
+
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -6305,6 +6267,18 @@ glob@7.2.0, glob@^7.1.3, glob@^7.1.4, glob@^7.1.7:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.6:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -8761,19 +8735,19 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
+mime-types@2.1.35, mime-types@^2.1.28:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mime-types@^2.1.12, mime-types@^2.1.18, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
   integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
   dependencies:
     mime-db "1.51.0"
-
-mime-types@^2.1.28:
-  version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
-  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
-  dependencies:
-    mime-db "1.52.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -8829,6 +8803,13 @@ minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
+
+minimatch@^3.0.2, minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -9899,6 +9880,11 @@ pluralize@8.0.0, pluralize@^8.0.0:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
+pony-cause@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pony-cause/-/pony-cause-1.1.1.tgz#f795524f83bebbf1878bd3587b45f69143cbf3f9"
+  integrity sha512-PxkIc/2ZpLiEzQXu5YRDOUgBlfGYBY8156HY5ZcRAwwonMk5W/MrJP2LLkG/hF7GEQzaHo2aS7ho6ZLCOvf+6g==
+
 portfinder@^1.0.28:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
@@ -10843,6 +10829,13 @@ rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -11532,6 +11525,11 @@ streamsearch@0.1.2:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
   integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
 
+string-argv@~0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
+
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
@@ -12043,6 +12041,11 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+type-fest@^2.0.0:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.13.1.tgz#621c84220df0e01a8469002594fc005714f0cfba"
+  integrity sha512-hXYyrPFwETT2swFLHeoKtJrvSF/ftG/sA15/8nGaLuaDGfVAaq8DYFpu4yOyV4tzp082WqnTEoMsm3flKMI2FQ==
+
 type-is@^1.6.14, type-is@^1.6.16, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -12068,12 +12071,17 @@ uglify-js@^3.1.4:
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.14.5.tgz#cdabb7d4954231d80cb4a927654c4655e51f4859"
   integrity sha512-qZukoSxOG0urUTvjc2ERMTcAy+BiFh3weWAkeurLwjrCba73poHmG3E36XEjd/JGukMzwTL7uCxZiAexj8ppvQ==
 
-umzug@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/umzug/-/umzug-2.3.0.tgz#0ef42b62df54e216b05dcaf627830a6a8b84a184"
-  integrity sha512-Z274K+e8goZK8QJxmbRPhl89HPO1K+ORFtm6rySPhFKfKc5GHhqdzD0SGhSWHkzoXasqJuItdhorSvY7/Cgflw==
+umzug@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/umzug/-/umzug-3.1.1.tgz#dfbe52308bf2908984380bdffd0c75c07831fd1f"
+  integrity sha512-sgMDzUK6ZKS3pjzRJpAHqSkvAQ+64Dourq6JfQv11i0nMu0/QqE3V3AUpj2pWYxFBaSvnUxKrzZQmPr6NZhvdQ==
   dependencies:
-    bluebird "^3.7.2"
+    "@rushstack/ts-command-line" "^4.7.7"
+    emittery "^0.10.2"
+    fs-jetpack "^4.1.0"
+    glob "^7.1.6"
+    pony-cause "^1.1.1"
+    type-fest "^2.0.0"
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
* In order to use the sentry fix provided by the sentry-plugin version 4.1.10.
* Migration Script mentioned in https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.1.8-to-4.1.10.html not necessary on our data state