### PR TITLE
Refactor the beforeUpdate picture lifecycle to a custom mutation

### DIFF
--- a/projects/bp-gallery/src/graphql/APIConnector.tsx
+++ b/projects/bp-gallery/src/graphql/APIConnector.tsx
@@ -650,6 +650,7 @@ export type Mutation = {
   updateLocationTag?: Maybe<LocationTagEntityResponse>;
   updatePersonTag?: Maybe<PersonTagEntityResponse>;
   updatePicture?: Maybe<PictureEntityResponse>;
+  updatePictureWithTagCleanup?: Maybe<Scalars['ID']>;
   updateTimeRangeTag?: Maybe<TimeRangeTagEntityResponse>;
   updateUploadFile?: Maybe<UploadFileEntityResponse>;
   /** Update an existing role */
@@ -855,6 +856,11 @@ export type MutationUpdatePersonTagArgs = {
 export type MutationUpdatePictureArgs = {
   data: PictureInput;
   id: Scalars['ID'];
+};
+
+export type MutationUpdatePictureWithTagCleanupArgs = {
+  data?: InputMaybe<Scalars['JSON']>;
+  id?: InputMaybe<Scalars['ID']>;
 };
 
 export type MutationUpdateTimeRangeTagArgs = {
@@ -2650,15 +2656,10 @@ export type CreateSubCollectionMutation = {
 
 export type UpdatePictureMutationVariables = Exact<{
   pictureId: Scalars['ID'];
-  data: PictureInput;
+  data: Scalars['JSON'];
 }>;
 
-export type UpdatePictureMutation = {
-  updatePicture?:
-    | { data?: { id?: string | null | undefined } | null | undefined }
-    | null
-    | undefined;
-};
+export type UpdatePictureMutation = { updatePictureWithTagCleanup?: string | null | undefined };
 
 export type CreatePictureMutationVariables = Exact<{
   data: PictureInput;
@@ -5197,12 +5198,8 @@ export type CreateSubCollectionMutationOptions = Apollo.BaseMutationOptions<
 >;
 
 export const UpdatePictureDocument = gql`
-  mutation updatePicture($pictureId: ID!, $data: PictureInput!) {
-    updatePicture(id: $pictureId, data: $data) {
-      data {
-        id
-      }
-    }
+  mutation updatePicture($pictureId: ID!, $data: JSON!) {
+    updatePictureWithTagCleanup(id: $pictureId, data: $data)
   }
 `;
 

--- a/projects/bp-gallery/src/graphql/operation.graphql
+++ b/projects/bp-gallery/src/graphql/operation.graphql
@@ -668,12 +668,8 @@ mutation createSubCollection($name: String!, $parentId: ID!, $publishedAt: DateT
   }
 }
 
-mutation updatePicture($pictureId: ID!, $data: PictureInput!) {
-  updatePicture(id: $pictureId, data: $data) {
-    data {
-      id
-    }
-  }
+mutation updatePicture($pictureId: ID!, $data: JSON!) {
+  updatePictureWithTagCleanup(id: $pictureId, data: $data)
 }
 
 mutation createPicture($data: PictureInput!) {

--- a/projects/bp-gallery/src/graphql/schema/schema.json
+++ b/projects/bp-gallery/src/graphql/schema/schema.json
@@ -12547,6 +12547,39 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "updatePictureWithTagCleanup",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "data",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "JSON",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,

--- a/projects/bp-strapi/src/api/picture/services/custom-resolver.js
+++ b/projects/bp-strapi/src/api/picture/services/custom-resolver.js
@@ -153,9 +153,9 @@ const findPicturesByAllSearch = async (knexEngine, searchTerms, searchTimes, pag
   return preparePictureDataForFrontend(matchingPictures, mediaFilesForPictures);
 };
 
-const { updatePictureWithCustomHandling } = require("./custom-update");
+const { updatePictureWithTagCleanup } = require("./custom-update");
 
 module.exports = {
   findPicturesByAllSearch,
-  updatePictureWithCustomHandling,
+  updatePictureWithTagCleanup,
 };

--- a/projects/bp-strapi/src/api/picture/services/custom-resolver.js
+++ b/projects/bp-strapi/src/api/picture/services/custom-resolver.js
@@ -153,6 +153,9 @@ const findPicturesByAllSearch = async (knexEngine, searchTerms, searchTimes, pag
   return preparePictureDataForFrontend(matchingPictures, mediaFilesForPictures);
 };
 
+const { updatePictureWithCustomHandling } = require("./custom-update");
+
 module.exports = {
   findPicturesByAllSearch,
+  updatePictureWithCustomHandling,
 };

--- a/projects/bp-strapi/src/api/picture/services/custom-update.js
+++ b/projects/bp-strapi/src/api/picture/services/custom-update.js
@@ -458,6 +458,8 @@ const updatePictureWithCustomHandling = async (id, data) =>  {
     where: { id },
     data,
   });
+
+  return id;
 };
 
 module.exports = {

--- a/projects/bp-strapi/src/api/picture/services/custom-update.js
+++ b/projects/bp-strapi/src/api/picture/services/custom-update.js
@@ -443,7 +443,7 @@ const processTagUpdates = async (pictureQuery, currentPictureId, data) => {
   await processUpdatesForPersonTags(data);
 };
 
-const updatePictureWithCustomHandling = async (id, data) =>  {
+const updatePictureWithTagCleanup = async (id, data) =>  {
   // No special handling needed if no data is passed.
   if (!data) return;
 
@@ -463,5 +463,5 @@ const updatePictureWithCustomHandling = async (id, data) =>  {
 };
 
 module.exports = {
-  updatePictureWithCustomHandling,
+  updatePictureWithTagCleanup,
 };

--- a/projects/bp-strapi/src/index.js
+++ b/projects/bp-strapi/src/index.js
@@ -5,7 +5,10 @@ const {
   mergeSourceCollectionIntoTargetCollection,
   resolveCollectionThumbnail,
 } = require("./api/collection/services/custom-resolver");
-const { findPicturesByAllSearch } = require("./api/picture/services/custom-resolver")
+const {
+  findPicturesByAllSearch,
+  updatePictureWithCustomHandling,
+} = require("./api/picture/services/custom-resolver")
 
 module.exports = {
   /**
@@ -81,6 +84,16 @@ module.exports = {
               );
             },
           }),
+          mutationField("updatePictureWithCustomHandling", {
+            type: "ID",
+            args: {
+              id: "ID",
+              data: "JSON",
+            },
+            async resolve(_, { id, data }) {
+              return updatePictureWithCustomHandling(id, data);
+            },
+          }),
           queryField("findPicturesByAllSearch", {
             type: list("PictureEntity"),
             args: {
@@ -122,6 +135,11 @@ module.exports = {
             mergeCollections: {
               auth: {
                 scope: ["api::collection.collection.update"],
+              },
+            },
+            updatePictureWithCustomHandling: {
+              auth: {
+                scope: ["api::picture.picture.update"],
               },
             },
           },

--- a/projects/bp-strapi/src/index.js
+++ b/projects/bp-strapi/src/index.js
@@ -84,7 +84,7 @@ module.exports = {
               );
             },
           }),
-          mutationField("updatePictureWithCustomHandling", {
+          mutationField("updatePictureWithTagCleanup", {
             type: "ID",
             args: {
               id: "ID",
@@ -137,7 +137,7 @@ module.exports = {
                 scope: ["api::collection.collection.update"],
               },
             },
-            updatePictureWithCustomHandling: {
+            updatePictureWithTagCleanup: {
               auth: {
                 scope: ["api::picture.picture.update"],
               },

--- a/projects/bp-strapi/src/index.js
+++ b/projects/bp-strapi/src/index.js
@@ -7,7 +7,7 @@ const {
 } = require("./api/collection/services/custom-resolver");
 const {
   findPicturesByAllSearch,
-  updatePictureWithCustomHandling,
+  updatePictureWithTagCleanup,
 } = require("./api/picture/services/custom-resolver")
 
 module.exports = {
@@ -91,7 +91,7 @@ module.exports = {
               data: "JSON",
             },
             async resolve(_, { id, data }) {
-              return updatePictureWithCustomHandling(id, data);
+              return updatePictureWithTagCleanup(id, data);
             },
           }),
           queryField("findPicturesByAllSearch", {


### PR DESCRIPTION
* Lifecycle --> Mutation, that executes basically the same logic (without JSON parsing needed anymore tho) and then executes the picture update itself at the end
* In that way the `beforeUpdate` semantics of the code can be kept