### PR TITLE
Further cleanup work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.idea
+.vscode

--- a/projects/bp-strapi/src/index.js
+++ b/projects/bp-strapi/src/index.js
@@ -147,6 +147,9 @@ module.exports = {
             thumbnail: {
               middlewares: [
                 async (_, parent) => {
+                  // The parent here is the actual collection, of which the thumbnail was requested.
+                  // More on the arguments of a resolver can be found for example on:
+                  // https://www.apollographql.com/docs/apollo-server/data/resolvers/#resolver-arguments
                   return resolveCollectionThumbnail(
                     extensionArgs.strapi,
                     parent.id,

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-############ VARIABLE DEFINITIONS ############
+############ VARIABLE DEFINITIONS - ADJUST THEM TO YOUR NEEDS ############
 BACKUP_DIR=/home/dev/backups/
-MEDIA_DIR=/home/dev/BP2021RH1/projects/bp-strapi/public/uploads
+MEDIA_DIR=# Insert path to uploads-directory of the Strapi instance you want to backup
 DB_NAME=bp-strapi
 DB_USER=postgres
 ##############################################

--- a/scripts/restore_backup.sh
+++ b/scripts/restore_backup.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
-
-############ VARIABLE DEFINITIONS ############
-MEDIA_DIR=/home/github/BP2021RH1/source/projects/bp-strapi/public/uploads
+############ VARIABLE DEFINITIONS - ADJUST THEM TO YOUR NEEDS ############
+MEDIA_DIR=# Insert path to uploads-directory of the Strapi instance you want to apply the backup to
 DB_NAME=bp-strapi
 ##############################################
 


### PR DESCRIPTION
* Code comments for custom GraphQL resolvers
* Adjust the root gitignore to ignore .vscode and .idea directories on root level
* Replace exact media directory in backup scripts with blanks (As the actual backup script that is executed on the server, is just copied from this repo state,the scripts in the repo should represent that sth. needs to be adjusted before those can be executed.)