### PR TITLE
Closes #157

### DIFF
--- a/projects/bp-gallery/src/components/views/picture/sidebar/picture-info/DateRangeSelectionField.tsx
+++ b/projects/bp-gallery/src/components/views/picture/sidebar/picture-info/DateRangeSelectionField.tsx
@@ -89,7 +89,7 @@ const DateRangeSelectionField = ({
             staticRanges={[]}
             inputRanges={INPUT_RANGES}
             dateDisplayFormat={'dd.MM.yyyy'}
-            minDate={dayjs(`1850-01-01`).toDate()}
+            minDate={dayjs(`100-01-01`).toDate()}
             maxDate={dayjs().add(1, 'year').toDate()}
             onChange={range => {
               if (range.selection.startDate && range.selection.endDate) {


### PR DESCRIPTION
Changes the limit of the datepicker to the year 100 (what should satisfy most usecases, since you can enter lower dates without using the datepicker).

Since the task is very specific and we are working on an external component, I didn't add any tests.