### PR TITLE
change picture description field from break-all to break-words

### DIFF
--- a/projects/bp-gallery/src/components/views/picture/sidebar/picture-info/DescriptionsEditField.tsx
+++ b/projects/bp-gallery/src/components/views/picture/sidebar/picture-info/DescriptionsEditField.tsx
@@ -81,7 +81,7 @@ const DescriptionsEditField = ({
                   onChange={newText => onChangeRef.current(newText, description)}
                 />
               ) : (
-                <RichText className='break-words' value={description.text} />
+                <RichText className='break-words overflow-x-hidden' value={description.text} />
               )}
             </div>
             <div>

--- a/projects/bp-gallery/src/components/views/picture/sidebar/picture-info/DescriptionsEditField.tsx
+++ b/projects/bp-gallery/src/components/views/picture/sidebar/picture-info/DescriptionsEditField.tsx
@@ -81,7 +81,7 @@ const DescriptionsEditField = ({
                   onChange={newText => onChangeRef.current(newText, description)}
                 />
               ) : (
-                <RichText className='break-all' value={description.text} />
+                <RichText className='break-words' value={description.text} />
               )}
             </div>
             <div>


### PR DESCRIPTION
Closes #301 

break-words breaks in some hyper specific cases, for example:
![image](https://user-images.githubusercontent.com/64468276/224709200-1e413f98-6fc0-4220-9f36-a477e2ceadc1.png)
(which is the reason why I used break-all in the first place)

The DailyPicture is currently broken in the same way, but this just isn't a bug that happens that often.
![image](https://user-images.githubusercontent.com/64468276/224711414-9532617c-3686-43c8-81d0-a1955982f53d.png)


Unfortunately break-all just doesn't look good and in cases like these we should probably just hide the overflow.