### PR TITLE
366 clipboardeditor sollte beim hovern einen titel anzeigen

### DIFF
--- a/projects/bp-gallery/cypress/e2e/link-pictures-with-texts.cy.ts
+++ b/projects/bp-gallery/cypress/e2e/link-pictures-with-texts.cy.ts
@@ -90,7 +90,7 @@ describe('link pictures with texts', () => {
 
   it('link a picture to a text', () => {
     cy.visit('/picture/2');
-    cy.get('.clipboard-editor-open').click();
+    cy.get('.clipboard-editor-open').should('have.attr', 'title', 'Kopierte Links').click();
     cy.contains('.clipboard-editor', 'Keine Bilder');
     cy.contains('.clipboard-editor button', 'Aktuelles Bild kopieren').click();
     cy.get('.clipboard-editor #picture-preview-for-2');

--- a/projects/bp-gallery/src/components/common/clipboard/ClipboardEditor.tsx
+++ b/projects/bp-gallery/src/components/common/clipboard/ClipboardEditor.tsx
@@ -74,6 +74,7 @@ export const ClipboardEditor = () => {
         )}
       </div>
       <Button
+        title={t('common.clipboard.name')}
         className='clipboard-editor-open'
         variant='contained'
         onClick={() => {


### PR DESCRIPTION
Fixes #366.