### PR TITLE
memo PictureEditDialog to stop rerenders

### DIFF
--- a/projects/bp-gallery/src/components/common/editors/ImageEditor.tsx
+++ b/projects/bp-gallery/src/components/common/editors/ImageEditor.tsx
@@ -16,9 +16,7 @@ const ImageEditor = ({
   useEffect(() => {
     // There's currently a bug in the tui image editor where it always throws an unhandled rejection error upon loading an image. Since the image still loads and the error is in the tui image editor itself and therefore not fixable by us, I've decided to just ignore it until the package gets updated.
     const onUnhandledRejection = (event: PromiseRejectionEvent) => {
-      if (
-        (event.reason.message as string).includes("Cannot read properties of null (reading 'fire')")
-      ) {
+      if (event.reason instanceof TypeError && event.reason.message.includes('null')) {
         event.preventDefault();
         event.stopPropagation();
       }

--- a/projects/bp-gallery/src/components/views/picture/sidebar/PictureSidebar.tsx
+++ b/projects/bp-gallery/src/components/views/picture/sidebar/PictureSidebar.tsx
@@ -10,6 +10,7 @@ import QueryErrorDisplay from '../../../common/QueryErrorDisplay';
 import { AuthRole, useAuth } from '../../../provider/AuthProvider';
 import { PictureViewContext } from '../PictureView';
 import PictureViewNavigationBar from '../overlay/PictureViewNavigationBar';
+import './PictureSidebar.scss';
 import CommentsContainer from './comments/CommentsContainer';
 import PictureEditDialog from './picture-info/PictureEditDialog';
 import PictureInfo, { Field } from './picture-info/PictureInfo';

--- a/projects/bp-gallery/src/components/views/picture/sidebar/PictureSidebar.tsx
+++ b/projects/bp-gallery/src/components/views/picture/sidebar/PictureSidebar.tsx
@@ -1,19 +1,19 @@
-import { useCallback, useContext, useMemo, useRef, useState } from 'react';
-import './PictureSidebar.scss';
-import PictureViewNavigationBar from '../overlay/PictureViewNavigationBar';
 import { ApolloError } from '@apollo/client';
-import CommentsContainer from './comments/CommentsContainer';
+import { Crop } from '@mui/icons-material';
+import { Button } from '@mui/material';
+import { useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useUpdatePictureMutation } from '../../../../graphql/APIConnector';
 import { FlatPicture } from '../../../../types/additionalFlatTypes';
-import { PictureViewContext } from '../PictureView';
 import Loading from '../../../common/Loading';
 import QueryErrorDisplay from '../../../common/QueryErrorDisplay';
-import PictureInfo, { Field } from './picture-info/PictureInfo';
 import { AuthRole, useAuth } from '../../../provider/AuthProvider';
-import { useTranslation } from 'react-i18next';
-import { Button } from '@mui/material';
-import { Crop } from '@mui/icons-material';
+import { PictureViewContext } from '../PictureView';
+import PictureViewNavigationBar from '../overlay/PictureViewNavigationBar';
+import './PictureSidebar.scss';
+import CommentsContainer from './comments/CommentsContainer';
 import PictureEditDialog from './picture-info/PictureEditDialog';
-import { useUpdatePictureMutation } from '../../../../graphql/APIConnector';
+import PictureInfo, { Field } from './picture-info/PictureInfo';
 
 const PictureSidebar = ({
   picture,
@@ -81,6 +81,7 @@ const PictureSidebar = ({
   // on every render and sets the clipboard editor buttons,
   // which triggers a rerender of the ClipboardEditor, completing the loop.
   const pictureIds = useMemo(() => (picture ? [picture.id] : []), [picture]);
+  const onDialogClose = useCallback(() => setEditDialogOpen(false), []);
 
   return (
     <div
@@ -105,7 +106,7 @@ const PictureSidebar = ({
                   <PictureEditDialog
                     picture={picture}
                     open={editDialogOpen}
-                    onClose={() => setEditDialogOpen(false)}
+                    onClose={onDialogClose}
                   />
                   <span className='save-state'>{saveStatus(anyFieldTouched, isSaving)}</span>
                 </div>

--- a/projects/bp-gallery/src/components/views/picture/sidebar/picture-info/PictureEditDialog.tsx
+++ b/projects/bp-gallery/src/components/views/picture/sidebar/picture-info/PictureEditDialog.tsx
@@ -2,7 +2,7 @@ import { useApolloClient } from '@apollo/client';
 import { Close, Save } from '@mui/icons-material';
 import { AppBar, Button, Dialog, DialogContent, Toolbar, Typography } from '@mui/material';
 import dayjs from 'dayjs';
-import { useCallback, useContext, useRef } from 'react';
+import { memo, useCallback, useContext, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type TuiImageEditor from 'tui-image-editor';
 import { asApiPath } from '../../../../../helpers/app-helpers';
@@ -16,7 +16,7 @@ const isDefaultCropZone = (rect: any) => {
   return rect.width < 1 || rect.height < 1;
 };
 
-const PictureEditDialog = ({
+const PictureEditDialog = memo(function PictureEditDialog({
   picture,
   open,
   onClose,
@@ -24,7 +24,7 @@ const PictureEditDialog = ({
   picture: FlatPicture;
   open: boolean;
   onClose: () => void;
-}) => {
+}) {
   const { t } = useTranslation();
   const editorRef = useRef<TuiImageEditor | null>(null);
   const apolloClient = useApolloClient();
@@ -107,6 +107,6 @@ const PictureEditDialog = ({
       </DialogContent>
     </Dialog>
   );
-};
+});
 
 export default PictureEditDialog;


### PR DESCRIPTION
Closes #445 

Moving your mouse constantly rerenders everything inside the FaceTaggingProvider, including the ImageEditor. The ImageEditor isn't made to be rerendered constantly and is therefore becoming unusable.