### PR TITLE
471 enhance growthbook analysis

### DIFF
--- a/projects/bp-gallery/src/helpers/growthbook.ts
+++ b/projects/bp-gallery/src/helpers/growthbook.ts
@@ -38,8 +38,8 @@ export const growthbook =
             'trackEvent',
             'FeatureViewed',
             featureKey,
-            'v' + String(result.experimentResult),
-            Number(result.on),
+            String(result.value),
+            Number(result.experimentResult?.variationId),
           ]);
         },
       })

--- a/projects/bp-gallery/src/helpers/growthbook.ts
+++ b/projects/bp-gallery/src/helpers/growthbook.ts
@@ -34,7 +34,13 @@ export const growthbook =
         onFeatureUsage: (featureKey, result) => {
           const w: any = window;
           const _paq: Array<any> = (w._paq = w._paq || []);
-          _paq.push(['trackEvent', 'FeatureViewed', featureKey, 'v' + String(result)]);
+          _paq.push([
+            'trackEvent',
+            'FeatureViewed',
+            featureKey,
+            'v' + String(result.experimentResult),
+            Number(result.on),
+          ]);
         },
       })
     : undefined;

--- a/projects/bp-gallery/src/helpers/growthbook.ts
+++ b/projects/bp-gallery/src/helpers/growthbook.ts
@@ -36,7 +36,7 @@ export const growthbook =
           const _paq: Array<any> = (w._paq = w._paq || []);
           _paq.push([
             'trackEvent',
-            'FeatureViewed' + '_s_' + String(result.source),
+            'FeatureViewed' + '_' + String(result.source),
             featureKey,
             'v' + String(result.value),
             Number(result.experimentResult?.variationId),

--- a/projects/bp-gallery/src/helpers/growthbook.ts
+++ b/projects/bp-gallery/src/helpers/growthbook.ts
@@ -36,9 +36,9 @@ export const growthbook =
           const _paq: Array<any> = (w._paq = w._paq || []);
           _paq.push([
             'trackEvent',
-            'FeatureViewed',
+            'FeatureViewed' + '_s_' + String(result.source),
             featureKey,
-            String(result.value),
+            'v' + String(result.value),
             Number(result.experimentResult?.variationId),
           ]);
         },


### PR DESCRIPTION
Adjust growthbook tracking call for onFeatureUsage

Current Format example:
category:"FeatureViewed", 
action: "dummy_experiment",
name: "v[object Object]"

New format example (hopefully):
category:"FeatureViewed_defaultValue"
action: "dummy_experiment"
name: "vTrue"  (FeatureValue - hopefully)
value: "0" (ExperimentvariationId)

