### PR TITLE
594 further improve loading time for hierarchy

### DIFF
--- a/projects/bp-gallery/src/components/views/picture/sidebar/picture-info/PictureInfo.tsx
+++ b/projects/bp-gallery/src/components/views/picture/sidebar/picture-info/PictureInfo.tsx
@@ -93,7 +93,7 @@ const PictureInfo = ({
   const openAlert = useContext(AlertContext);
 
   const allKeywords = useSimplifiedQueryResponseData(keywordsResponse.data)?.keywordTags;
-  const allLocations = useSimplifiedQueryResponseData(locationsResponse.data)?.locationTags;
+  const allLocations = useSimplifiedQueryResponseData(locationsResponse.data)?.getAllLocationTags;
   const allPeople = useSimplifiedQueryResponseData(peopleResponse.data)?.personTags;
   const allCollections = useSimplifiedQueryResponseData(collectionsResponse.data)?.collections;
 

--- a/projects/bp-gallery/src/components/views/picture/sidebar/picture-info/SingleTagElement.tsx
+++ b/projects/bp-gallery/src/components/views/picture/sidebar/picture-info/SingleTagElement.tsx
@@ -103,7 +103,7 @@ const SingleTagElement = ({
   return (
     <div className='recommendation-item-container'>
       <div className='recommendation-item-content'>
-        {tagSupertags && typeof option.id === 'string' && tagSupertags.length > 0 ? (
+        {tagSupertags && tagSupertags.length > 0 ? (
           <>
             {tagSupertags.length > 1 ? (
               <MultiPathTagElement

--- a/projects/bp-gallery/src/graphql/APIConnector.tsx
+++ b/projects/bp-gallery/src/graphql/APIConnector.tsx
@@ -1967,6 +1967,7 @@ export type Query = {
   faceTag?: Maybe<FaceTagEntityResponse>;
   faceTags?: Maybe<FaceTagEntityResponseCollection>;
   findPicturesByAllSearch?: Maybe<Array<Maybe<PictureEntity>>>;
+  getAllLocationTags?: Maybe<Scalars['JSON']>;
   keywordTag?: Maybe<KeywordTagEntityResponse>;
   keywordTags?: Maybe<KeywordTagEntityResponseCollection>;
   link?: Maybe<LinkEntityResponse>;
@@ -2733,27 +2734,7 @@ export type GetAllKeywordTagsQuery = {
 
 export type GetAllLocationTagsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetAllLocationTagsQuery = {
-  locationTags?: {
-    data: Array<{
-      id?: string | null;
-      attributes?: {
-        name: string;
-        visible?: boolean | null;
-        root?: boolean | null;
-        accepted?: boolean | null;
-        coordinates?: { latitude: number; longitude: number } | null;
-        synonyms?: Array<{ name: string } | null> | null;
-        child_tags?: {
-          data: Array<{ id?: string | null; attributes?: { name: string } | null }>;
-        } | null;
-        parent_tags?: {
-          data: Array<{ id?: string | null; attributes?: { name: string } | null }>;
-        } | null;
-      } | null;
-    }>;
-  } | null;
-};
+export type GetAllLocationTagsQuery = { getAllLocationTags?: any | null };
 
 export type GetAllPersonTagsQueryVariables = Exact<{ [key: string]: never }>;
 
@@ -4661,40 +4642,7 @@ export type GetAllKeywordTagsQueryResult = Apollo.QueryResult<
 
 export const GetAllLocationTagsDocument = gql`
   query getAllLocationTags {
-    locationTags {
-      data {
-        id
-        attributes {
-          name
-          visible
-          root
-          accepted
-          coordinates {
-            latitude
-            longitude
-          }
-          synonyms {
-            name
-          }
-          child_tags {
-            data {
-              id
-              attributes {
-                name
-              }
-            }
-          }
-          parent_tags {
-            data {
-              id
-              attributes {
-                name
-              }
-            }
-          }
-        }
-      }
-    }
+    getAllLocationTags
   }
 `;
 

--- a/projects/bp-gallery/src/graphql/operation.graphql
+++ b/projects/bp-gallery/src/graphql/operation.graphql
@@ -3,7 +3,7 @@ query canRunOperation( $operation: String! $variableSets: [JSON!] $withSomeVaria
 query getAllArchiveTags($sortBy: [String] = ["createdAt:asc"]) { archiveTags(sort: $sortBy) { data { id attributes { name shortDescription showcasePicture { data { id attributes { media { data { attributes { url updatedAt provider } } } } } } } } } }
 query getAllCollections { collections(publicationState: PREVIEW) { data { id attributes { name parent_collections(publicationState: PREVIEW) { data { id attributes { name } } } } } } }
 query getAllKeywordTags { keywordTags { data { id attributes { name visible synonyms { name } } } } }
-query getAllLocationTags { locationTags { data { id attributes { name visible root accepted coordinates { latitude longitude } synonyms { name } child_tags { data { id attributes { name } } } parent_tags { data { id attributes { name } } } } } } }
+query getAllLocationTags { getAllLocationTags }
 query getAllPersonTags { personTags { data { id attributes { name synonyms { name } } } } }
 query getAllPictureIds { pictures { data { id } } }
 query getArchive($archiveId: ID!) { archiveTag(id: $archiveId) { data { id attributes { name shortDescription longDescription email paypalClient paypalDonationText paypalPurpose restrictImageDownloading logo { data { id attributes { width height formats updatedAt provider } } } showcasePicture { data { id attributes { media { data { id attributes { width height formats url updatedAt provider } } } } } } links { data { id attributes { title url } } } } } } }

--- a/projects/bp-gallery/src/graphql/schema/schema.json
+++ b/projects/bp-gallery/src/graphql/schema/schema.json
@@ -17475,6 +17475,18 @@
             "deprecationReason": null
           },
           {
+            "name": "getAllLocationTags",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSON",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "findPicturesByAllSearch",
             "description": null,
             "args": [

--- a/projects/bp-graphql/src/operations/getAllLocationTags.ts
+++ b/projects/bp-graphql/src/operations/getAllLocationTags.ts
@@ -6,40 +6,7 @@ export default {
   isAllowed: always,
   document: graphql`
     query getAllLocationTags {
-      locationTags {
-        data {
-          id
-          attributes {
-            name
-            visible
-            root
-            accepted
-            coordinates {
-              latitude
-              longitude
-            }
-            synonyms {
-              name
-            }
-            child_tags {
-              data {
-                id
-                attributes {
-                  name
-                }
-              }
-            }
-            parent_tags {
-              data {
-                id
-                attributes {
-                  name
-                }
-              }
-            }
-          }
-        }
-      }
+      getAllLocationTags
     }
   `,
 } satisfies Operation;

--- a/projects/bp-strapi/schemas.d.ts
+++ b/projects/bp-strapi/schemas.d.ts
@@ -1,43 +1,43 @@
 import {
-  BooleanAttribute,
   CollectionTypeSchema,
+  StringAttribute,
+  RequiredAttribute,
+  SetMinMaxLength,
+  JSONAttribute,
+  DefaultTo,
+  RelationAttribute,
+  DateTimeAttribute,
+  PrivateAttribute,
+  EmailAttribute,
+  UniqueAttribute,
+  PasswordAttribute,
+  BooleanAttribute,
+  EnumerationAttribute,
+  IntegerAttribute,
+  DecimalAttribute,
+  SetMinMax,
+  RichTextAttribute,
+  TextAttribute,
+  MediaAttribute,
+  SingleTypeSchema,
+  FloatAttribute,
   ComponentAttribute,
   ComponentSchema,
-  DateTimeAttribute,
-  DecimalAttribute,
-  DefaultTo,
-  EmailAttribute,
-  EnumerationAttribute,
-  FloatAttribute,
-  IntegerAttribute,
-  JSONAttribute,
-  MediaAttribute,
-  PasswordAttribute,
-  PrivateAttribute,
-  RelationAttribute,
-  RequiredAttribute,
-  RichTextAttribute,
-  SetMinMax,
-  SetMinMaxLength,
-  SingleTypeSchema,
-  StringAttribute,
-  TextAttribute,
-  UniqueAttribute,
-} from "@strapi/strapi";
+} from '@strapi/strapi';
 
 export interface AdminPermission extends CollectionTypeSchema {
   info: {
-    name: "Permission";
-    description: "";
-    singularName: "permission";
-    pluralName: "permissions";
-    displayName: "Permission";
+    name: 'Permission';
+    description: '';
+    singularName: 'permission';
+    pluralName: 'permissions';
+    displayName: 'Permission';
   };
   pluginOptions: {
-    "content-manager": {
+    'content-manager': {
       visible: false;
     };
-    "content-type-builder": {
+    'content-type-builder': {
       visible: false;
     };
   };
@@ -53,37 +53,27 @@ export interface AdminPermission extends CollectionTypeSchema {
       }>;
     properties: JSONAttribute & DefaultTo<{}>;
     conditions: JSONAttribute & DefaultTo<[]>;
-    role: RelationAttribute<"admin::permission", "manyToOne", "admin::role">;
+    role: RelationAttribute<'admin::permission', 'manyToOne', 'admin::role'>;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "admin::permission",
-      "oneToOne",
-      "admin::user"
-    > &
-      PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "admin::permission",
-      "oneToOne",
-      "admin::user"
-    > &
-      PrivateAttribute;
+    createdBy: RelationAttribute<'admin::permission', 'oneToOne', 'admin::user'> & PrivateAttribute;
+    updatedBy: RelationAttribute<'admin::permission', 'oneToOne', 'admin::user'> & PrivateAttribute;
   };
 }
 
 export interface AdminUser extends CollectionTypeSchema {
   info: {
-    name: "User";
-    description: "";
-    singularName: "user";
-    pluralName: "users";
-    displayName: "User";
+    name: 'User';
+    description: '';
+    singularName: 'user';
+    pluralName: 'users';
+    displayName: 'User';
   };
   pluginOptions: {
-    "content-manager": {
+    'content-manager': {
       visible: false;
     };
-    "content-type-builder": {
+    'content-type-builder': {
       visible: false;
     };
   };
@@ -112,32 +102,29 @@ export interface AdminUser extends CollectionTypeSchema {
     resetPasswordToken: StringAttribute & PrivateAttribute;
     registrationToken: StringAttribute & PrivateAttribute;
     isActive: BooleanAttribute & PrivateAttribute & DefaultTo<false>;
-    roles: RelationAttribute<"admin::user", "manyToMany", "admin::role"> &
-      PrivateAttribute;
+    roles: RelationAttribute<'admin::user', 'manyToMany', 'admin::role'> & PrivateAttribute;
     blocked: BooleanAttribute & PrivateAttribute & DefaultTo<false>;
     preferedLanguage: StringAttribute;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<"admin::user", "oneToOne", "admin::user"> &
-      PrivateAttribute;
-    updatedBy: RelationAttribute<"admin::user", "oneToOne", "admin::user"> &
-      PrivateAttribute;
+    createdBy: RelationAttribute<'admin::user', 'oneToOne', 'admin::user'> & PrivateAttribute;
+    updatedBy: RelationAttribute<'admin::user', 'oneToOne', 'admin::user'> & PrivateAttribute;
   };
 }
 
 export interface AdminRole extends CollectionTypeSchema {
   info: {
-    name: "Role";
-    description: "";
-    singularName: "role";
-    pluralName: "roles";
-    displayName: "Role";
+    name: 'Role';
+    description: '';
+    singularName: 'role';
+    pluralName: 'roles';
+    displayName: 'Role';
   };
   pluginOptions: {
-    "content-manager": {
+    'content-manager': {
       visible: false;
     };
-    "content-type-builder": {
+    'content-type-builder': {
       visible: false;
     };
   };
@@ -155,34 +142,28 @@ export interface AdminRole extends CollectionTypeSchema {
         minLength: 1;
       }>;
     description: StringAttribute;
-    users: RelationAttribute<"admin::role", "manyToMany", "admin::user">;
-    permissions: RelationAttribute<
-      "admin::role",
-      "oneToMany",
-      "admin::permission"
-    >;
+    users: RelationAttribute<'admin::role', 'manyToMany', 'admin::user'>;
+    permissions: RelationAttribute<'admin::role', 'oneToMany', 'admin::permission'>;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<"admin::role", "oneToOne", "admin::user"> &
-      PrivateAttribute;
-    updatedBy: RelationAttribute<"admin::role", "oneToOne", "admin::user"> &
-      PrivateAttribute;
+    createdBy: RelationAttribute<'admin::role', 'oneToOne', 'admin::user'> & PrivateAttribute;
+    updatedBy: RelationAttribute<'admin::role', 'oneToOne', 'admin::user'> & PrivateAttribute;
   };
 }
 
 export interface AdminApiToken extends CollectionTypeSchema {
   info: {
-    name: "Api Token";
-    singularName: "api-token";
-    pluralName: "api-tokens";
-    displayName: "Api Token";
-    description: "";
+    name: 'Api Token';
+    singularName: 'api-token';
+    pluralName: 'api-tokens';
+    displayName: 'Api Token';
+    description: '';
   };
   pluginOptions: {
-    "content-manager": {
+    'content-manager': {
       visible: false;
     };
-    "content-type-builder": {
+    'content-type-builder': {
       visible: false;
     };
   };
@@ -197,53 +178,39 @@ export interface AdminApiToken extends CollectionTypeSchema {
       SetMinMaxLength<{
         minLength: 1;
       }> &
-      DefaultTo<"">;
-    type: EnumerationAttribute<["read-only", "full-access", "custom"]> &
+      DefaultTo<''>;
+    type: EnumerationAttribute<['read-only', 'full-access', 'custom']> &
       RequiredAttribute &
-      DefaultTo<"read-only">;
+      DefaultTo<'read-only'>;
     accessKey: StringAttribute &
       RequiredAttribute &
       SetMinMaxLength<{
         minLength: 1;
       }>;
     lastUsedAt: DateTimeAttribute;
-    permissions: RelationAttribute<
-      "admin::api-token",
-      "oneToMany",
-      "admin::api-token-permission"
-    >;
+    permissions: RelationAttribute<'admin::api-token', 'oneToMany', 'admin::api-token-permission'>;
     expiresAt: DateTimeAttribute;
     lifespan: IntegerAttribute;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "admin::api-token",
-      "oneToOne",
-      "admin::user"
-    > &
-      PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "admin::api-token",
-      "oneToOne",
-      "admin::user"
-    > &
-      PrivateAttribute;
+    createdBy: RelationAttribute<'admin::api-token', 'oneToOne', 'admin::user'> & PrivateAttribute;
+    updatedBy: RelationAttribute<'admin::api-token', 'oneToOne', 'admin::user'> & PrivateAttribute;
   };
 }
 
 export interface AdminApiTokenPermission extends CollectionTypeSchema {
   info: {
-    name: "API Token Permission";
-    description: "";
-    singularName: "api-token-permission";
-    pluralName: "api-token-permissions";
-    displayName: "API Token Permission";
+    name: 'API Token Permission';
+    description: '';
+    singularName: 'api-token-permission';
+    pluralName: 'api-token-permissions';
+    displayName: 'API Token Permission';
   };
   pluginOptions: {
-    "content-manager": {
+    'content-manager': {
       visible: false;
     };
-    "content-type-builder": {
+    'content-type-builder': {
       visible: false;
     };
   };
@@ -253,40 +220,28 @@ export interface AdminApiTokenPermission extends CollectionTypeSchema {
       SetMinMaxLength<{
         minLength: 1;
       }>;
-    token: RelationAttribute<
-      "admin::api-token-permission",
-      "manyToOne",
-      "admin::api-token"
-    >;
+    token: RelationAttribute<'admin::api-token-permission', 'manyToOne', 'admin::api-token'>;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "admin::api-token-permission",
-      "oneToOne",
-      "admin::user"
-    > &
+    createdBy: RelationAttribute<'admin::api-token-permission', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "admin::api-token-permission",
-      "oneToOne",
-      "admin::user"
-    > &
+    updatedBy: RelationAttribute<'admin::api-token-permission', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
   };
 }
 
 export interface PluginUploadFile extends CollectionTypeSchema {
   info: {
-    singularName: "file";
-    pluralName: "files";
-    displayName: "File";
-    description: "";
+    singularName: 'file';
+    pluralName: 'files';
+    displayName: 'File';
+    description: '';
   };
   pluginOptions: {
-    "content-manager": {
+    'content-manager': {
       visible: false;
     };
-    "content-type-builder": {
+    'content-type-builder': {
       visible: false;
     };
   };
@@ -305,12 +260,8 @@ export interface PluginUploadFile extends CollectionTypeSchema {
     previewUrl: StringAttribute;
     provider: StringAttribute & RequiredAttribute;
     provider_metadata: JSONAttribute;
-    related: RelationAttribute<"plugin::upload.file", "morphToMany">;
-    folder: RelationAttribute<
-      "plugin::upload.file",
-      "manyToOne",
-      "plugin::upload.folder"
-    > &
+    related: RelationAttribute<'plugin::upload.file', 'morphToMany'>;
+    folder: RelationAttribute<'plugin::upload.file', 'manyToOne', 'plugin::upload.folder'> &
       PrivateAttribute;
     folderPath: StringAttribute &
       RequiredAttribute &
@@ -320,32 +271,24 @@ export interface PluginUploadFile extends CollectionTypeSchema {
       }>;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "plugin::upload.file",
-      "oneToOne",
-      "admin::user"
-    > &
+    createdBy: RelationAttribute<'plugin::upload.file', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "plugin::upload.file",
-      "oneToOne",
-      "admin::user"
-    > &
+    updatedBy: RelationAttribute<'plugin::upload.file', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
   };
 }
 
 export interface PluginUploadFolder extends CollectionTypeSchema {
   info: {
-    singularName: "folder";
-    pluralName: "folders";
-    displayName: "Folder";
+    singularName: 'folder';
+    pluralName: 'folders';
+    displayName: 'Folder';
   };
   pluginOptions: {
-    "content-manager": {
+    'content-manager': {
       visible: false;
     };
-    "content-type-builder": {
+    'content-type-builder': {
       visible: false;
     };
   };
@@ -356,21 +299,9 @@ export interface PluginUploadFolder extends CollectionTypeSchema {
         min: 1;
       }>;
     pathId: IntegerAttribute & RequiredAttribute & UniqueAttribute;
-    parent: RelationAttribute<
-      "plugin::upload.folder",
-      "manyToOne",
-      "plugin::upload.folder"
-    >;
-    children: RelationAttribute<
-      "plugin::upload.folder",
-      "oneToMany",
-      "plugin::upload.folder"
-    >;
-    files: RelationAttribute<
-      "plugin::upload.folder",
-      "oneToMany",
-      "plugin::upload.file"
-    >;
+    parent: RelationAttribute<'plugin::upload.folder', 'manyToOne', 'plugin::upload.folder'>;
+    children: RelationAttribute<'plugin::upload.folder', 'oneToMany', 'plugin::upload.folder'>;
+    files: RelationAttribute<'plugin::upload.folder', 'oneToMany', 'plugin::upload.file'>;
     path: StringAttribute &
       RequiredAttribute &
       SetMinMax<{
@@ -378,56 +309,48 @@ export interface PluginUploadFolder extends CollectionTypeSchema {
       }>;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "plugin::upload.folder",
-      "oneToOne",
-      "admin::user"
-    > &
+    createdBy: RelationAttribute<'plugin::upload.folder', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "plugin::upload.folder",
-      "oneToOne",
-      "admin::user"
-    > &
+    updatedBy: RelationAttribute<'plugin::upload.folder', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
   };
 }
 
 export interface PluginUsersPermissionsPermission extends CollectionTypeSchema {
   info: {
-    name: "permission";
-    description: "";
-    singularName: "permission";
-    pluralName: "permissions";
-    displayName: "Permission";
+    name: 'permission';
+    description: '';
+    singularName: 'permission';
+    pluralName: 'permissions';
+    displayName: 'Permission';
   };
   pluginOptions: {
-    "content-manager": {
+    'content-manager': {
       visible: false;
     };
-    "content-type-builder": {
+    'content-type-builder': {
       visible: false;
     };
   };
   attributes: {
     action: StringAttribute & RequiredAttribute;
     role: RelationAttribute<
-      "plugin::users-permissions.permission",
-      "manyToOne",
-      "plugin::users-permissions.role"
+      'plugin::users-permissions.permission',
+      'manyToOne',
+      'plugin::users-permissions.role'
     >;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
     createdBy: RelationAttribute<
-      "plugin::users-permissions.permission",
-      "oneToOne",
-      "admin::user"
+      'plugin::users-permissions.permission',
+      'oneToOne',
+      'admin::user'
     > &
       PrivateAttribute;
     updatedBy: RelationAttribute<
-      "plugin::users-permissions.permission",
-      "oneToOne",
-      "admin::user"
+      'plugin::users-permissions.permission',
+      'oneToOne',
+      'admin::user'
     > &
       PrivateAttribute;
   };
@@ -435,17 +358,17 @@ export interface PluginUsersPermissionsPermission extends CollectionTypeSchema {
 
 export interface PluginUsersPermissionsRole extends CollectionTypeSchema {
   info: {
-    name: "role";
-    description: "";
-    singularName: "role";
-    pluralName: "roles";
-    displayName: "Role";
+    name: 'role';
+    description: '';
+    singularName: 'role';
+    pluralName: 'roles';
+    displayName: 'Role';
   };
   pluginOptions: {
-    "content-manager": {
+    'content-manager': {
       visible: false;
     };
-    "content-type-builder": {
+    'content-type-builder': {
       visible: false;
     };
   };
@@ -458,39 +381,31 @@ export interface PluginUsersPermissionsRole extends CollectionTypeSchema {
     description: StringAttribute;
     type: StringAttribute & UniqueAttribute;
     permissions: RelationAttribute<
-      "plugin::users-permissions.role",
-      "oneToMany",
-      "plugin::users-permissions.permission"
+      'plugin::users-permissions.role',
+      'oneToMany',
+      'plugin::users-permissions.permission'
     >;
     users: RelationAttribute<
-      "plugin::users-permissions.role",
-      "oneToMany",
-      "plugin::users-permissions.user"
+      'plugin::users-permissions.role',
+      'oneToMany',
+      'plugin::users-permissions.user'
     >;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "plugin::users-permissions.role",
-      "oneToOne",
-      "admin::user"
-    > &
+    createdBy: RelationAttribute<'plugin::users-permissions.role', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "plugin::users-permissions.role",
-      "oneToOne",
-      "admin::user"
-    > &
+    updatedBy: RelationAttribute<'plugin::users-permissions.role', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
   };
 }
 
 export interface PluginUsersPermissionsUser extends CollectionTypeSchema {
   info: {
-    name: "user";
-    description: "";
-    singularName: "user";
-    pluralName: "users";
-    displayName: "User";
+    name: 'user';
+    description: '';
+    singularName: 'user';
+    pluralName: 'users';
+    displayName: 'User';
   };
   options: {
     draftAndPublish: false;
@@ -519,107 +434,95 @@ export interface PluginUsersPermissionsUser extends CollectionTypeSchema {
     confirmed: BooleanAttribute & DefaultTo<false>;
     blocked: BooleanAttribute & DefaultTo<false>;
     role: RelationAttribute<
-      "plugin::users-permissions.user",
-      "manyToOne",
-      "plugin::users-permissions.role"
+      'plugin::users-permissions.user',
+      'manyToOne',
+      'plugin::users-permissions.role'
     >;
+    isSuperUser: BooleanAttribute & DefaultTo<false>;
+    resetPasswordTokenCreatedAt: DateTimeAttribute;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "plugin::users-permissions.user",
-      "oneToOne",
-      "admin::user"
-    > &
+    createdBy: RelationAttribute<'plugin::users-permissions.user', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "plugin::users-permissions.user",
-      "oneToOne",
-      "admin::user"
-    > &
+    updatedBy: RelationAttribute<'plugin::users-permissions.user', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
   };
 }
 
 export interface ApiArchiveTagArchiveTag extends CollectionTypeSchema {
   info: {
-    singularName: "archive-tag";
-    pluralName: "archive-tags";
-    displayName: "Archive_Tag";
-    description: "";
+    singularName: 'archive-tag';
+    pluralName: 'archive-tags';
+    displayName: 'Archive_Tag';
+    description: '';
   };
   options: {
-    draftAndPublish: false;
+    draftAndPublish: true;
   };
   attributes: {
     name: StringAttribute & RequiredAttribute & UniqueAttribute;
     pictures: RelationAttribute<
-      "api::archive-tag.archive-tag",
-      "oneToMany",
-      "api::picture.picture"
+      'api::archive-tag.archive-tag',
+      'oneToMany',
+      'api::picture.picture'
     >;
     longDescription: RichTextAttribute;
     showcasePicture: RelationAttribute<
-      "api::archive-tag.archive-tag",
-      "oneToOne",
-      "api::picture.picture"
+      'api::archive-tag.archive-tag',
+      'oneToOne',
+      'api::picture.picture'
     >;
-    links: RelationAttribute<
-      "api::archive-tag.archive-tag",
-      "oneToMany",
-      "api::link.link"
-    >;
+    links: RelationAttribute<'api::archive-tag.archive-tag', 'oneToMany', 'api::link.link'>;
     shortDescription: TextAttribute;
     logo: MediaAttribute;
     paypalClient: StringAttribute;
     paypalDonationText: StringAttribute;
     paypalPurpose: StringAttribute;
+    restrictImageDownloading: BooleanAttribute;
     email: EmailAttribute;
+    exhibitions: RelationAttribute<
+      'api::archive-tag.archive-tag',
+      'oneToMany',
+      'api::exhibition.exhibition'
+    >;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "api::archive-tag.archive-tag",
-      "oneToOne",
-      "admin::user"
-    > &
+    publishedAt: DateTimeAttribute;
+    createdBy: RelationAttribute<'api::archive-tag.archive-tag', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "api::archive-tag.archive-tag",
-      "oneToOne",
-      "admin::user"
-    > &
+    updatedBy: RelationAttribute<'api::archive-tag.archive-tag', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
   };
 }
 
-export interface ApiBrowseRootCollectionBrowseRootCollection
-  extends SingleTypeSchema {
+export interface ApiBrowseRootCollectionBrowseRootCollection extends SingleTypeSchema {
   info: {
-    singularName: "browse-root-collection";
-    pluralName: "browse-root-collections";
-    displayName: "Browse root collection";
+    singularName: 'browse-root-collection';
+    pluralName: 'browse-root-collections';
+    displayName: 'Browse root collection';
   };
   options: {
     draftAndPublish: true;
   };
   attributes: {
     current: RelationAttribute<
-      "api::browse-root-collection.browse-root-collection",
-      "oneToOne",
-      "api::collection.collection"
+      'api::browse-root-collection.browse-root-collection',
+      'oneToOne',
+      'api::collection.collection'
     >;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
     publishedAt: DateTimeAttribute;
     createdBy: RelationAttribute<
-      "api::browse-root-collection.browse-root-collection",
-      "oneToOne",
-      "admin::user"
+      'api::browse-root-collection.browse-root-collection',
+      'oneToOne',
+      'admin::user'
     > &
       PrivateAttribute;
     updatedBy: RelationAttribute<
-      "api::browse-root-collection.browse-root-collection",
-      "oneToOne",
-      "admin::user"
+      'api::browse-root-collection.browse-root-collection',
+      'oneToOne',
+      'admin::user'
     > &
       PrivateAttribute;
   };
@@ -627,10 +530,10 @@ export interface ApiBrowseRootCollectionBrowseRootCollection
 
 export interface ApiCollectionCollection extends CollectionTypeSchema {
   info: {
-    singularName: "collection";
-    pluralName: "collections";
-    displayName: "Collection";
-    description: "";
+    singularName: 'collection';
+    pluralName: 'collections';
+    displayName: 'Collection';
+    description: '';
   };
   options: {
     draftAndPublish: true;
@@ -639,45 +542,33 @@ export interface ApiCollectionCollection extends CollectionTypeSchema {
     name: StringAttribute & RequiredAttribute & UniqueAttribute;
     description: RichTextAttribute;
     child_collections: RelationAttribute<
-      "api::collection.collection",
-      "manyToMany",
-      "api::collection.collection"
+      'api::collection.collection',
+      'manyToMany',
+      'api::collection.collection'
     >;
     parent_collections: RelationAttribute<
-      "api::collection.collection",
-      "manyToMany",
-      "api::collection.collection"
+      'api::collection.collection',
+      'manyToMany',
+      'api::collection.collection'
     >;
-    pictures: RelationAttribute<
-      "api::collection.collection",
-      "manyToMany",
-      "api::picture.picture"
-    >;
+    pictures: RelationAttribute<'api::collection.collection', 'manyToMany', 'api::picture.picture'>;
     thumbnail: StringAttribute;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
     publishedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "api::collection.collection",
-      "oneToOne",
-      "admin::user"
-    > &
+    createdBy: RelationAttribute<'api::collection.collection', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "api::collection.collection",
-      "oneToOne",
-      "admin::user"
-    > &
+    updatedBy: RelationAttribute<'api::collection.collection', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
   };
 }
 
 export interface ApiCommentComment extends CollectionTypeSchema {
   info: {
-    singularName: "comment";
-    pluralName: "comments";
-    displayName: "Comment";
-    description: "";
+    singularName: 'comment';
+    pluralName: 'comments';
+    displayName: 'Comment';
+    description: '';
   };
   options: {
     draftAndPublish: true;
@@ -686,45 +577,25 @@ export interface ApiCommentComment extends CollectionTypeSchema {
     author: StringAttribute;
     text: RichTextAttribute & RequiredAttribute;
     date: DateTimeAttribute & RequiredAttribute;
-    picture: RelationAttribute<
-      "api::comment.comment",
-      "manyToOne",
-      "api::picture.picture"
-    >;
+    picture: RelationAttribute<'api::comment.comment', 'manyToOne', 'api::picture.picture'>;
     pinned: BooleanAttribute & DefaultTo<false>;
-    childComments: RelationAttribute<
-      "api::comment.comment",
-      "oneToMany",
-      "api::comment.comment"
-    >;
-    parentComment: RelationAttribute<
-      "api::comment.comment",
-      "manyToOne",
-      "api::comment.comment"
-    >;
+    childComments: RelationAttribute<'api::comment.comment', 'oneToMany', 'api::comment.comment'>;
+    parentComment: RelationAttribute<'api::comment.comment', 'manyToOne', 'api::comment.comment'>;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
     publishedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "api::comment.comment",
-      "oneToOne",
-      "admin::user"
-    > &
+    createdBy: RelationAttribute<'api::comment.comment', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "api::comment.comment",
-      "oneToOne",
-      "admin::user"
-    > &
+    updatedBy: RelationAttribute<'api::comment.comment', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
   };
 }
 
 export interface ApiDescriptionDescription extends CollectionTypeSchema {
   info: {
-    singularName: "description";
-    pluralName: "descriptions";
-    displayName: "Description";
+    singularName: 'description';
+    pluralName: 'descriptions';
+    displayName: 'Description';
   };
   options: {
     draftAndPublish: true;
@@ -732,23 +603,187 @@ export interface ApiDescriptionDescription extends CollectionTypeSchema {
   attributes: {
     text: RichTextAttribute & RequiredAttribute;
     pictures: RelationAttribute<
-      "api::description.description",
-      "manyToMany",
-      "api::picture.picture"
+      'api::description.description',
+      'manyToMany',
+      'api::picture.picture'
+    >;
+    createdAt: DateTimeAttribute;
+    updatedAt: DateTimeAttribute;
+    publishedAt: DateTimeAttribute;
+    createdBy: RelationAttribute<'api::description.description', 'oneToOne', 'admin::user'> &
+      PrivateAttribute;
+    updatedBy: RelationAttribute<'api::description.description', 'oneToOne', 'admin::user'> &
+      PrivateAttribute;
+  };
+}
+
+export interface ApiExhibitionExhibition extends CollectionTypeSchema {
+  info: {
+    singularName: 'exhibition';
+    pluralName: 'exhibitions';
+    displayName: 'Exhibition';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: StringAttribute;
+    introduction: RichTextAttribute;
+    title_picture: RelationAttribute<
+      'api::exhibition.exhibition',
+      'oneToOne',
+      'api::exhibition-picture.exhibition-picture'
+    >;
+    exhibition_sections: RelationAttribute<
+      'api::exhibition.exhibition',
+      'oneToMany',
+      'api::exhibition-section.exhibition-section'
+    >;
+    epilog: RichTextAttribute;
+    exhibition_sources: RelationAttribute<
+      'api::exhibition.exhibition',
+      'oneToMany',
+      'api::exhibition-source.exhibition-source'
+    >;
+    idealot_pictures: RelationAttribute<
+      'api::exhibition.exhibition',
+      'oneToMany',
+      'api::exhibition-picture.exhibition-picture'
+    >;
+    is_published: BooleanAttribute;
+    archive_tag: RelationAttribute<
+      'api::exhibition.exhibition',
+      'manyToOne',
+      'api::archive-tag.archive-tag'
+    >;
+    createdAt: DateTimeAttribute;
+    updatedAt: DateTimeAttribute;
+    publishedAt: DateTimeAttribute;
+    createdBy: RelationAttribute<'api::exhibition.exhibition', 'oneToOne', 'admin::user'> &
+      PrivateAttribute;
+    updatedBy: RelationAttribute<'api::exhibition.exhibition', 'oneToOne', 'admin::user'> &
+      PrivateAttribute;
+  };
+}
+
+export interface ApiExhibitionPictureExhibitionPicture extends CollectionTypeSchema {
+  info: {
+    singularName: 'exhibition-picture';
+    pluralName: 'exhibition-pictures';
+    displayName: 'Exhibition_Picture';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    picture: RelationAttribute<
+      'api::exhibition-picture.exhibition-picture',
+      'manyToOne',
+      'api::picture.picture'
+    >;
+    subtitle: StringAttribute;
+    exhibition_section: RelationAttribute<
+      'api::exhibition-picture.exhibition-picture',
+      'manyToOne',
+      'api::exhibition-section.exhibition-section'
+    >;
+    exhibition_idealot: RelationAttribute<
+      'api::exhibition-picture.exhibition-picture',
+      'manyToOne',
+      'api::exhibition.exhibition'
+    >;
+    order: IntegerAttribute;
+    createdAt: DateTimeAttribute;
+    updatedAt: DateTimeAttribute;
+    publishedAt: DateTimeAttribute;
+    createdBy: RelationAttribute<
+      'api::exhibition-picture.exhibition-picture',
+      'oneToOne',
+      'admin::user'
+    > &
+      PrivateAttribute;
+    updatedBy: RelationAttribute<
+      'api::exhibition-picture.exhibition-picture',
+      'oneToOne',
+      'admin::user'
+    > &
+      PrivateAttribute;
+  };
+}
+
+export interface ApiExhibitionSectionExhibitionSection extends CollectionTypeSchema {
+  info: {
+    singularName: 'exhibition-section';
+    pluralName: 'exhibition-sections';
+    displayName: 'Exhibition_Section';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: StringAttribute;
+    text: RichTextAttribute;
+    exhibition_pictures: RelationAttribute<
+      'api::exhibition-section.exhibition-section',
+      'oneToMany',
+      'api::exhibition-picture.exhibition-picture'
+    >;
+    exhibition: RelationAttribute<
+      'api::exhibition-section.exhibition-section',
+      'manyToOne',
+      'api::exhibition.exhibition'
+    >;
+    order: IntegerAttribute;
+    createdAt: DateTimeAttribute;
+    updatedAt: DateTimeAttribute;
+    publishedAt: DateTimeAttribute;
+    createdBy: RelationAttribute<
+      'api::exhibition-section.exhibition-section',
+      'oneToOne',
+      'admin::user'
+    > &
+      PrivateAttribute;
+    updatedBy: RelationAttribute<
+      'api::exhibition-section.exhibition-section',
+      'oneToOne',
+      'admin::user'
+    > &
+      PrivateAttribute;
+  };
+}
+
+export interface ApiExhibitionSourceExhibitionSource extends CollectionTypeSchema {
+  info: {
+    singularName: 'exhibition-source';
+    pluralName: 'exhibition-sources';
+    displayName: 'Exhibition_Source';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    source: StringAttribute;
+    exhibition: RelationAttribute<
+      'api::exhibition-source.exhibition-source',
+      'manyToOne',
+      'api::exhibition.exhibition'
     >;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
     publishedAt: DateTimeAttribute;
     createdBy: RelationAttribute<
-      "api::description.description",
-      "oneToOne",
-      "admin::user"
+      'api::exhibition-source.exhibition-source',
+      'oneToOne',
+      'admin::user'
     > &
       PrivateAttribute;
     updatedBy: RelationAttribute<
-      "api::description.description",
-      "oneToOne",
-      "admin::user"
+      'api::exhibition-source.exhibition-source',
+      'oneToOne',
+      'admin::user'
     > &
       PrivateAttribute;
   };
@@ -756,10 +791,10 @@ export interface ApiDescriptionDescription extends CollectionTypeSchema {
 
 export interface ApiFaceTagFaceTag extends CollectionTypeSchema {
   info: {
-    singularName: "face-tag";
-    pluralName: "face-tags";
-    displayName: "Face_Tag";
-    description: "";
+    singularName: 'face-tag';
+    pluralName: 'face-tags';
+    displayName: 'Face_Tag';
+    description: '';
   };
   options: {
     draftAndPublish: false;
@@ -768,39 +803,27 @@ export interface ApiFaceTagFaceTag extends CollectionTypeSchema {
     x: FloatAttribute;
     y: FloatAttribute;
     person_tag: RelationAttribute<
-      "api::face-tag.face-tag",
-      "oneToOne",
-      "api::person-tag.person-tag"
+      'api::face-tag.face-tag',
+      'oneToOne',
+      'api::person-tag.person-tag'
     >;
-    picture: RelationAttribute<
-      "api::face-tag.face-tag",
-      "manyToOne",
-      "api::picture.picture"
-    >;
+    picture: RelationAttribute<'api::face-tag.face-tag', 'manyToOne', 'api::picture.picture'>;
     tag_direction: IntegerAttribute;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "api::face-tag.face-tag",
-      "oneToOne",
-      "admin::user"
-    > &
+    createdBy: RelationAttribute<'api::face-tag.face-tag', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "api::face-tag.face-tag",
-      "oneToOne",
-      "admin::user"
-    > &
+    updatedBy: RelationAttribute<'api::face-tag.face-tag', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
   };
 }
 
 export interface ApiKeywordTagKeywordTag extends CollectionTypeSchema {
   info: {
-    singularName: "keyword-tag";
-    pluralName: "keyword-tags";
-    displayName: "Keyword_Tag";
-    description: "";
+    singularName: 'keyword-tag';
+    pluralName: 'keyword-tags';
+    displayName: 'Keyword_Tag';
+    description: '';
   };
   options: {
     draftAndPublish: false;
@@ -808,40 +831,32 @@ export interface ApiKeywordTagKeywordTag extends CollectionTypeSchema {
   attributes: {
     name: StringAttribute & RequiredAttribute & UniqueAttribute;
     pictures: RelationAttribute<
-      "api::keyword-tag.keyword-tag",
-      "manyToMany",
-      "api::picture.picture"
+      'api::keyword-tag.keyword-tag',
+      'manyToMany',
+      'api::picture.picture'
     >;
     verified_pictures: RelationAttribute<
-      "api::keyword-tag.keyword-tag",
-      "manyToMany",
-      "api::picture.picture"
+      'api::keyword-tag.keyword-tag',
+      'manyToMany',
+      'api::picture.picture'
     >;
-    synonyms: ComponentAttribute<"common.synonyms", true>;
+    synonyms: ComponentAttribute<'common.synonyms', true>;
     visible: BooleanAttribute & DefaultTo<false>;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "api::keyword-tag.keyword-tag",
-      "oneToOne",
-      "admin::user"
-    > &
+    createdBy: RelationAttribute<'api::keyword-tag.keyword-tag', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "api::keyword-tag.keyword-tag",
-      "oneToOne",
-      "admin::user"
-    > &
+    updatedBy: RelationAttribute<'api::keyword-tag.keyword-tag', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
   };
 }
 
 export interface ApiLinkLink extends CollectionTypeSchema {
   info: {
-    singularName: "link";
-    pluralName: "links";
-    displayName: "Link";
-    description: "";
+    singularName: 'link';
+    pluralName: 'links';
+    displayName: 'Link';
+    description: '';
   };
   options: {
     draftAndPublish: false;
@@ -849,57 +864,95 @@ export interface ApiLinkLink extends CollectionTypeSchema {
   attributes: {
     title: RichTextAttribute;
     url: RichTextAttribute & RequiredAttribute;
-    archive_tag: RelationAttribute<
-      "api::link.link",
-      "manyToOne",
-      "api::archive-tag.archive-tag"
-    >;
+    archive_tag: RelationAttribute<'api::link.link', 'manyToOne', 'api::archive-tag.archive-tag'>;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<"api::link.link", "oneToOne", "admin::user"> &
-      PrivateAttribute;
-    updatedBy: RelationAttribute<"api::link.link", "oneToOne", "admin::user"> &
-      PrivateAttribute;
+    createdBy: RelationAttribute<'api::link.link', 'oneToOne', 'admin::user'> & PrivateAttribute;
+    updatedBy: RelationAttribute<'api::link.link', 'oneToOne', 'admin::user'> & PrivateAttribute;
   };
 }
 
 export interface ApiLocationTagLocationTag extends CollectionTypeSchema {
   info: {
-    singularName: "location-tag";
-    pluralName: "location-tags";
-    displayName: "Location_Tag";
-    description: "";
+    singularName: 'location-tag';
+    pluralName: 'location-tags';
+    displayName: 'Location_Tag';
+    description: '';
   };
   options: {
     draftAndPublish: false;
   };
   attributes: {
     name: StringAttribute & RequiredAttribute;
-    coordinates: ComponentAttribute<"location.coordinates">;
+    coordinates: ComponentAttribute<'location.coordinates'>;
     pictures: RelationAttribute<
-      "api::location-tag.location-tag",
-      "manyToMany",
-      "api::picture.picture"
+      'api::location-tag.location-tag',
+      'manyToMany',
+      'api::picture.picture'
     >;
     verified_pictures: RelationAttribute<
-      "api::location-tag.location-tag",
-      "manyToMany",
-      "api::picture.picture"
+      'api::location-tag.location-tag',
+      'manyToMany',
+      'api::picture.picture'
     >;
-    synonyms: ComponentAttribute<"common.synonyms", true>;
+    synonyms: ComponentAttribute<'common.synonyms', true>;
     visible: BooleanAttribute & DefaultTo<false>;
+    parent_tags: RelationAttribute<
+      'api::location-tag.location-tag',
+      'manyToMany',
+      'api::location-tag.location-tag'
+    >;
+    child_tags: RelationAttribute<
+      'api::location-tag.location-tag',
+      'manyToMany',
+      'api::location-tag.location-tag'
+    >;
+    accepted: BooleanAttribute;
+    root: BooleanAttribute;
+    createdAt: DateTimeAttribute;
+    updatedAt: DateTimeAttribute;
+    createdBy: RelationAttribute<'api::location-tag.location-tag', 'oneToOne', 'admin::user'> &
+      PrivateAttribute;
+    updatedBy: RelationAttribute<'api::location-tag.location-tag', 'oneToOne', 'admin::user'> &
+      PrivateAttribute;
+  };
+}
+
+export interface ApiParameterizedPermissionParameterizedPermission extends CollectionTypeSchema {
+  info: {
+    singularName: 'parameterized-permission';
+    pluralName: 'parameterized-permissions';
+    displayName: 'Parameterized_Permission';
+    description: '';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    operation_name: StringAttribute;
+    users_permissions_user: RelationAttribute<
+      'api::parameterized-permission.parameterized-permission',
+      'oneToOne',
+      'plugin::users-permissions.user'
+    >;
+    archive_tag: RelationAttribute<
+      'api::parameterized-permission.parameterized-permission',
+      'oneToOne',
+      'api::archive-tag.archive-tag'
+    >;
+    on_other_users: BooleanAttribute;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
     createdBy: RelationAttribute<
-      "api::location-tag.location-tag",
-      "oneToOne",
-      "admin::user"
+      'api::parameterized-permission.parameterized-permission',
+      'oneToOne',
+      'admin::user'
     > &
       PrivateAttribute;
     updatedBy: RelationAttribute<
-      "api::location-tag.location-tag",
-      "oneToOne",
-      "admin::user"
+      'api::parameterized-permission.parameterized-permission',
+      'oneToOne',
+      'admin::user'
     > &
       PrivateAttribute;
   };
@@ -907,50 +960,38 @@ export interface ApiLocationTagLocationTag extends CollectionTypeSchema {
 
 export interface ApiPersonTagPersonTag extends CollectionTypeSchema {
   info: {
-    singularName: "person-tag";
-    pluralName: "person-tags";
-    displayName: "Person_Tag";
-    description: "";
+    singularName: 'person-tag';
+    pluralName: 'person-tags';
+    displayName: 'Person_Tag';
+    description: '';
   };
   options: {
     draftAndPublish: false;
   };
   attributes: {
     name: StringAttribute & RequiredAttribute & UniqueAttribute;
-    pictures: RelationAttribute<
-      "api::person-tag.person-tag",
-      "manyToMany",
-      "api::picture.picture"
-    >;
+    pictures: RelationAttribute<'api::person-tag.person-tag', 'manyToMany', 'api::picture.picture'>;
     verified_pictures: RelationAttribute<
-      "api::person-tag.person-tag",
-      "manyToMany",
-      "api::picture.picture"
+      'api::person-tag.person-tag',
+      'manyToMany',
+      'api::picture.picture'
     >;
-    synonyms: ComponentAttribute<"common.synonyms", true>;
+    synonyms: ComponentAttribute<'common.synonyms', true>;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "api::person-tag.person-tag",
-      "oneToOne",
-      "admin::user"
-    > &
+    createdBy: RelationAttribute<'api::person-tag.person-tag', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "api::person-tag.person-tag",
-      "oneToOne",
-      "admin::user"
-    > &
+    updatedBy: RelationAttribute<'api::person-tag.person-tag', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
   };
 }
 
 export interface ApiPicturePicture extends CollectionTypeSchema {
   info: {
-    singularName: "picture";
-    pluralName: "pictures";
-    displayName: "Picture";
-    description: "";
+    singularName: 'picture';
+    pluralName: 'pictures';
+    displayName: 'Picture';
+    description: '';
   };
   options: {
     draftAndPublish: true;
@@ -959,138 +1000,123 @@ export interface ApiPicturePicture extends CollectionTypeSchema {
     media: MediaAttribute & RequiredAttribute;
     wordpress_id: IntegerAttribute & UniqueAttribute;
     descriptions: RelationAttribute<
-      "api::picture.picture",
-      "manyToMany",
-      "api::description.description"
+      'api::picture.picture',
+      'manyToMany',
+      'api::description.description'
     >;
-    comments: RelationAttribute<
-      "api::picture.picture",
-      "oneToMany",
-      "api::comment.comment"
-    >;
+    comments: RelationAttribute<'api::picture.picture', 'oneToMany', 'api::comment.comment'>;
     keyword_tags: RelationAttribute<
-      "api::picture.picture",
-      "manyToMany",
-      "api::keyword-tag.keyword-tag"
+      'api::picture.picture',
+      'manyToMany',
+      'api::keyword-tag.keyword-tag'
     >;
     time_range_tag: RelationAttribute<
-      "api::picture.picture",
-      "manyToOne",
-      "api::time-range-tag.time-range-tag"
+      'api::picture.picture',
+      'manyToOne',
+      'api::time-range-tag.time-range-tag'
     >;
     collections: RelationAttribute<
-      "api::picture.picture",
-      "manyToMany",
-      "api::collection.collection"
+      'api::picture.picture',
+      'manyToMany',
+      'api::collection.collection'
     >;
     person_tags: RelationAttribute<
-      "api::picture.picture",
-      "manyToMany",
-      "api::person-tag.person-tag"
+      'api::picture.picture',
+      'manyToMany',
+      'api::person-tag.person-tag'
     >;
     location_tags: RelationAttribute<
-      "api::picture.picture",
-      "manyToMany",
-      "api::location-tag.location-tag"
+      'api::picture.picture',
+      'manyToMany',
+      'api::location-tag.location-tag'
     >;
     verified_person_tags: RelationAttribute<
-      "api::picture.picture",
-      "manyToMany",
-      "api::person-tag.person-tag"
+      'api::picture.picture',
+      'manyToMany',
+      'api::person-tag.person-tag'
     >;
     verified_location_tags: RelationAttribute<
-      "api::picture.picture",
-      "manyToMany",
-      "api::location-tag.location-tag"
+      'api::picture.picture',
+      'manyToMany',
+      'api::location-tag.location-tag'
     >;
     verified_keyword_tags: RelationAttribute<
-      "api::picture.picture",
-      "manyToMany",
-      "api::keyword-tag.keyword-tag"
+      'api::picture.picture',
+      'manyToMany',
+      'api::keyword-tag.keyword-tag'
     >;
     verified_time_range_tag: RelationAttribute<
-      "api::picture.picture",
-      "manyToOne",
-      "api::time-range-tag.time-range-tag"
+      'api::picture.picture',
+      'manyToOne',
+      'api::time-range-tag.time-range-tag'
     >;
     is_text: BooleanAttribute & DefaultTo<false>;
     archive_identifier: StringAttribute;
     archive_tag: RelationAttribute<
-      "api::picture.picture",
-      "manyToOne",
-      "api::archive-tag.archive-tag"
+      'api::picture.picture',
+      'manyToOne',
+      'api::archive-tag.archive-tag'
     >;
     likes: IntegerAttribute;
-    linked_texts: RelationAttribute<
-      "api::picture.picture",
-      "manyToMany",
-      "api::picture.picture"
-    >;
+    linked_texts: RelationAttribute<'api::picture.picture', 'manyToMany', 'api::picture.picture'>;
     linked_pictures: RelationAttribute<
-      "api::picture.picture",
-      "manyToMany",
-      "api::picture.picture"
+      'api::picture.picture',
+      'manyToMany',
+      'api::picture.picture'
     >;
     picture_geo_infos: RelationAttribute<
-      "api::picture.picture",
-      "oneToMany",
-      "api::picture-geo-info.picture-geo-info"
+      'api::picture.picture',
+      'oneToMany',
+      'api::picture-geo-info.picture-geo-info'
     >;
     is_not_a_place_count: IntegerAttribute;
-    face_tags: RelationAttribute<
-      "api::picture.picture",
-      "oneToMany",
-      "api::face-tag.face-tag"
+    face_tags: RelationAttribute<'api::picture.picture', 'oneToMany', 'api::face-tag.face-tag'>;
+    exhibition_pictures: RelationAttribute<
+      'api::picture.picture',
+      'oneToMany',
+      'api::exhibition-picture.exhibition-picture'
     >;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
     publishedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "api::picture.picture",
-      "oneToOne",
-      "admin::user"
-    > &
+    createdBy: RelationAttribute<'api::picture.picture', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "api::picture.picture",
-      "oneToOne",
-      "admin::user"
-    > &
+    updatedBy: RelationAttribute<'api::picture.picture', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
   };
 }
 
 export interface ApiPictureGeoInfoPictureGeoInfo extends CollectionTypeSchema {
   info: {
-    singularName: "picture-geo-info";
-    pluralName: "picture-geo-infos";
-    displayName: "Picture_Geo_Info";
-    description: "";
+    singularName: 'picture-geo-info';
+    pluralName: 'picture-geo-infos';
+    displayName: 'Picture_Geo_Info';
+    description: '';
   };
   options: {
     draftAndPublish: false;
   };
   attributes: {
     picture: RelationAttribute<
-      "api::picture-geo-info.picture-geo-info",
-      "manyToOne",
-      "api::picture.picture"
+      'api::picture-geo-info.picture-geo-info',
+      'manyToOne',
+      'api::picture.picture'
     >;
-    latitude: DecimalAttribute;
-    longitude: DecimalAttribute;
+    latitude: FloatAttribute;
+    longitude: FloatAttribute;
     radius: DecimalAttribute;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
     createdBy: RelationAttribute<
-      "api::picture-geo-info.picture-geo-info",
-      "oneToOne",
-      "admin::user"
+      'api::picture-geo-info.picture-geo-info',
+      'oneToOne',
+      'admin::user'
     > &
       PrivateAttribute;
     updatedBy: RelationAttribute<
-      "api::picture-geo-info.picture-geo-info",
-      "oneToOne",
-      "admin::user"
+      'api::picture-geo-info.picture-geo-info',
+      'oneToOne',
+      'admin::user'
     > &
       PrivateAttribute;
   };
@@ -1098,10 +1124,10 @@ export interface ApiPictureGeoInfoPictureGeoInfo extends CollectionTypeSchema {
 
 export interface ApiTimeRangeTagTimeRangeTag extends CollectionTypeSchema {
   info: {
-    singularName: "time-range-tag";
-    pluralName: "time-range-tags";
-    displayName: "Time_Range_Tag";
-    description: "";
+    singularName: 'time-range-tag';
+    pluralName: 'time-range-tags';
+    displayName: 'Time_Range_Tag';
+    description: '';
   };
   options: {
     draftAndPublish: false;
@@ -1110,38 +1136,30 @@ export interface ApiTimeRangeTagTimeRangeTag extends CollectionTypeSchema {
     start: DateTimeAttribute & RequiredAttribute;
     end: DateTimeAttribute & RequiredAttribute;
     pictures: RelationAttribute<
-      "api::time-range-tag.time-range-tag",
-      "oneToMany",
-      "api::picture.picture"
+      'api::time-range-tag.time-range-tag',
+      'oneToMany',
+      'api::picture.picture'
     >;
     verified_pictures: RelationAttribute<
-      "api::time-range-tag.time-range-tag",
-      "oneToMany",
-      "api::picture.picture"
+      'api::time-range-tag.time-range-tag',
+      'oneToMany',
+      'api::picture.picture'
     >;
     isEstimate: BooleanAttribute;
     createdAt: DateTimeAttribute;
     updatedAt: DateTimeAttribute;
-    createdBy: RelationAttribute<
-      "api::time-range-tag.time-range-tag",
-      "oneToOne",
-      "admin::user"
-    > &
+    createdBy: RelationAttribute<'api::time-range-tag.time-range-tag', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
-    updatedBy: RelationAttribute<
-      "api::time-range-tag.time-range-tag",
-      "oneToOne",
-      "admin::user"
-    > &
+    updatedBy: RelationAttribute<'api::time-range-tag.time-range-tag', 'oneToOne', 'admin::user'> &
       PrivateAttribute;
   };
 }
 
 export interface CommonSynonyms extends ComponentSchema {
   info: {
-    displayName: "synonym";
-    icon: "layer-group";
-    description: "";
+    displayName: 'synonym';
+    icon: 'layer-group';
+    description: '';
   };
   attributes: {
     name: StringAttribute & RequiredAttribute;
@@ -1150,8 +1168,8 @@ export interface CommonSynonyms extends ComponentSchema {
 
 export interface LocationCoordinates extends ComponentSchema {
   info: {
-    displayName: "Coordinates";
-    icon: "map-marked-alt";
+    displayName: 'Coordinates';
+    icon: 'map-marked-alt';
   };
   attributes: {
     latitude: FloatAttribute &
@@ -1172,31 +1190,36 @@ export interface LocationCoordinates extends ComponentSchema {
 declare global {
   namespace Strapi {
     interface Schemas {
-      "admin::permission": AdminPermission;
-      "admin::user": AdminUser;
-      "admin::role": AdminRole;
-      "admin::api-token": AdminApiToken;
-      "admin::api-token-permission": AdminApiTokenPermission;
-      "plugin::upload.file": PluginUploadFile;
-      "plugin::upload.folder": PluginUploadFolder;
-      "plugin::users-permissions.permission": PluginUsersPermissionsPermission;
-      "plugin::users-permissions.role": PluginUsersPermissionsRole;
-      "plugin::users-permissions.user": PluginUsersPermissionsUser;
-      "api::archive-tag.archive-tag": ApiArchiveTagArchiveTag;
-      "api::browse-root-collection.browse-root-collection": ApiBrowseRootCollectionBrowseRootCollection;
-      "api::collection.collection": ApiCollectionCollection;
-      "api::comment.comment": ApiCommentComment;
-      "api::description.description": ApiDescriptionDescription;
-      "api::face-tag.face-tag": ApiFaceTagFaceTag;
-      "api::keyword-tag.keyword-tag": ApiKeywordTagKeywordTag;
-      "api::link.link": ApiLinkLink;
-      "api::location-tag.location-tag": ApiLocationTagLocationTag;
-      "api::person-tag.person-tag": ApiPersonTagPersonTag;
-      "api::picture.picture": ApiPicturePicture;
-      "api::picture-geo-info.picture-geo-info": ApiPictureGeoInfoPictureGeoInfo;
-      "api::time-range-tag.time-range-tag": ApiTimeRangeTagTimeRangeTag;
-      "common.synonyms": CommonSynonyms;
-      "location.coordinates": LocationCoordinates;
+      'admin::permission': AdminPermission;
+      'admin::user': AdminUser;
+      'admin::role': AdminRole;
+      'admin::api-token': AdminApiToken;
+      'admin::api-token-permission': AdminApiTokenPermission;
+      'plugin::upload.file': PluginUploadFile;
+      'plugin::upload.folder': PluginUploadFolder;
+      'plugin::users-permissions.permission': PluginUsersPermissionsPermission;
+      'plugin::users-permissions.role': PluginUsersPermissionsRole;
+      'plugin::users-permissions.user': PluginUsersPermissionsUser;
+      'api::archive-tag.archive-tag': ApiArchiveTagArchiveTag;
+      'api::browse-root-collection.browse-root-collection': ApiBrowseRootCollectionBrowseRootCollection;
+      'api::collection.collection': ApiCollectionCollection;
+      'api::comment.comment': ApiCommentComment;
+      'api::description.description': ApiDescriptionDescription;
+      'api::exhibition.exhibition': ApiExhibitionExhibition;
+      'api::exhibition-picture.exhibition-picture': ApiExhibitionPictureExhibitionPicture;
+      'api::exhibition-section.exhibition-section': ApiExhibitionSectionExhibitionSection;
+      'api::exhibition-source.exhibition-source': ApiExhibitionSourceExhibitionSource;
+      'api::face-tag.face-tag': ApiFaceTagFaceTag;
+      'api::keyword-tag.keyword-tag': ApiKeywordTagKeywordTag;
+      'api::link.link': ApiLinkLink;
+      'api::location-tag.location-tag': ApiLocationTagLocationTag;
+      'api::parameterized-permission.parameterized-permission': ApiParameterizedPermissionParameterizedPermission;
+      'api::person-tag.person-tag': ApiPersonTagPersonTag;
+      'api::picture.picture': ApiPicturePicture;
+      'api::picture-geo-info.picture-geo-info': ApiPictureGeoInfoPictureGeoInfo;
+      'api::time-range-tag.time-range-tag': ApiTimeRangeTagTimeRangeTag;
+      'common.synonyms': CommonSynonyms;
+      'location.coordinates': LocationCoordinates;
     }
   }
 }

--- a/projects/bp-strapi/src/api/location-tag/services/custom-resolver.ts
+++ b/projects/bp-strapi/src/api/location-tag/services/custom-resolver.ts
@@ -1,7 +1,10 @@
 import { StrapiExtended } from '../../../types';
+import { deepStringifyIds } from '../../helper';
 
-export const getAllLocationTags = (strapi: StrapiExtended) =>
-  strapi.entityService.findMany('api::location-tag.location-tag', {
-    fields: ['name', 'visible', 'root', 'accepted'],
-    populate: ['coordinates', 'synonyms', 'parent_tags'],
-  });
+export const getAllLocationTags = async (strapi: StrapiExtended) =>
+  deepStringifyIds(
+    await strapi.entityService.findMany('api::location-tag.location-tag', {
+      fields: ['name', 'visible', 'root', 'accepted'],
+      populate: ['coordinates', 'synonyms', 'parent_tags'],
+    })
+  );

--- a/projects/bp-strapi/src/api/location-tag/services/custom-resolver.ts
+++ b/projects/bp-strapi/src/api/location-tag/services/custom-resolver.ts
@@ -1,0 +1,7 @@
+import { StrapiExtended } from '../../../types';
+
+export const getAllLocationTags = (strapi: StrapiExtended) =>
+  strapi.entityService.findMany('api::location-tag.location-tag', {
+    fields: ['name', 'visible', 'root', 'accepted'],
+    populate: ['coordinates', 'synonyms', 'parent_tags'],
+  });

--- a/projects/bp-strapi/src/index.ts
+++ b/projects/bp-strapi/src/index.ts
@@ -9,6 +9,7 @@ import {
 } from './api/collection/services/custom-resolver';
 import { contact } from './api/contact/services/contact';
 import { mergeSourceTagIntoTargetTag } from './api/custom-tag-resolver';
+import { getAllLocationTags } from './api/location-tag/services/custom-resolver';
 import {
   addPermission,
   addUser,
@@ -102,6 +103,13 @@ export default {
                 sourceId,
                 targetId
               );
+            },
+          }),
+          queryField('getAllLocationTags', {
+            type: 'JSON',
+            args: {},
+            resolve() {
+              return getAllLocationTags(strapi as StrapiExtended);
             },
           }),
           mutationField('updatePictureWithTagCleanup', {

--- a/projects/bp-strapi/src/types.ts
+++ b/projects/bp-strapi/src/types.ts
@@ -92,7 +92,9 @@ type ResponseAttributes<T extends Strapi.ContentTypeUIDs> =
     }> & { id: number });
 
 type PopulateType<T extends Strapi.ContentTypeUIDs> = {
-  [K in keyof GetAttributes<T> as GetAttributes<T>[K] extends Attribute<'relation'>
+  [K in keyof GetAttributes<T> as GetAttributes<T>[K] extends Attribute<
+    'relation' | 'component' | 'dynamiczone'
+  >
     ? K
     : never]: GetAttributes<T>[K];
 };


### PR DESCRIPTION
Closes #594

This results in a speedup from around 1400ms to 80-160ms for the `getAllLocationsQuery` in the locations curating view; connected to my local database containing the location tags from the staging database. Hopefully, we will see similar results when deployed.