### PR TITLE
docs: wip, update local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,14 @@ To understand our code it is important to know the fundamentals of TypeScript (i
 
 There are two main projects: [`bp-gallery`](/projects/bp-gallery) and [`bp-strapi`](/projects/bp-strapi). The [`bp-gallery`](/projects/bp-gallery) project includes the frontend code (React), [`bp-strapi`](/projects/bp-strapi) the backend code (Strapi).
 
-To start local development you first have to install [node](https://nodejs.org) (≥14, recommended: 16) and [yarn](https://yarnpkg.com/getting-started). After that you have to execute `yarn install` in the [`bp-gallery`](/projects/bp-gallery) directory to install the dependencies.
+To start local development you
 
-By using the command `yarn start` in the [`bp-gallery`](/projects/bp-gallery) directory you now can start a local instance of the React application. By default, this instance communicates with our production backend. How to set up a local backend instance and use it gets described [here](https://lilac-oriole-6ab.notion.site/How-to-setup-a-local-Strapi-instance-ffecc3d084e744dbb931715cc955ddfb).
+1. install [node](https://nodejs.org) (≥14, recommended: 16) and [yarn](https://yarnpkg.com/getting-started)
+2. execute `yarn` in the [`bp-gallery`](/projects/bp-gallery) directory to install the dependencies
+3. execute `yarn simple-generate-api` to generate API definitions
+4. execute `yarn start` in `projects/bp-gallery`
+5. in `projects/bp-strapi`, execute `yarn test-db` to launch a docker container running postgres
+6. same folder, run `yarn develop` to start the backend
+7. visit [http://localhost:3000/]()
 
 The whole Documentation can be found [here](https://lilac-oriole-6ab.notion.site/1ac4cd0f3bc54968a87e24a63653322a?v=06ffdc8582af49d9a9e7a4a33603399a).
-


### PR DESCRIPTION
- [ ] Ref #441, should also include instructions/script to load e2e test data.
- [ ] Should include instructions for a local meilisearch docker
- [ ] Should also update how to best connect to production instance without need for local strapi.

Feel free to contribute and push directly to this branch, otherwise I'll get on it over the course of the next week :)