### PR TITLE
Fix PictureSequenceInfoField sometimes showing no pictures

### DIFF
--- a/projects/bp-gallery/src/components/views/picture/sidebar/picture-info/PictureSequenceInfoField.tsx
+++ b/projects/bp-gallery/src/components/views/picture/sidebar/picture-info/PictureSequenceInfoField.tsx
@@ -85,6 +85,7 @@ const PictureSequenceInfoField = ({ picture }: { picture: FlatPicture }) => {
               textFilter={TextFilter.PICTURES_AND_TEXTS}
               cacheOnRefetch
               onSort={canEdit ? onSort : undefined}
+              fetchPolicy='cache-and-network'
             />
           </ScrollContainer>
         </ScrollProvider>


### PR DESCRIPTION
Closes #625

Before, when switching between two pictures, where the first is part of a  sequence, the the other pictures in the sequence are not shown when switching back to the first. The exact reason is unclear, however print debugging has shown that during switching, the correct array of pictures is displayed first, only to be replaced by an empty array shortly after. Since this commit fixes the issue by changing the `fetchPolicy` from `'cache-first'` (default) to `'cache-and-network'`, the problem is likely related to Apollo's caching behavior.