### PR TITLE
Fix removal of user leaking permissions to public user

### DIFF
--- a/projects/bp-strapi/src/api/parameterized-permission/services/custom-update.ts
+++ b/projects/bp-strapi/src/api/parameterized-permission/services/custom-update.ts
@@ -198,12 +198,6 @@ export const removeUser = async (id: string) => {
     return;
   }
 
-  await userQuery.delete({
-    where: {
-      id,
-    },
-  });
-
   const permissionQuery = strapi.db.query('api::parameterized-permission.parameterized-permission');
   // deleteMany currently doesn't support relational filters:
   // https://github.com/strapi/strapi/issues/11998
@@ -214,15 +208,19 @@ export const removeUser = async (id: string) => {
       },
     },
   });
-  await Promise.all(
-    permissionsToDelete.map(permission => {
-      permissionQuery.delete({
-        where: {
-          id: permission.id,
-        },
-      });
-    })
-  );
+  await permissionQuery.delete({
+    where: {
+      id: {
+        $in: permissionsToDelete.map(permission => permission.id),
+      },
+    },
+  });
+
+  await userQuery.delete({
+    where: {
+      id,
+    },
+  });
 
   return 1;
 };


### PR DESCRIPTION
Previously, the user was deleted before the user's permissions were looked up. The removal of the user cleared the `user` column of the user's permissions to `NULL`, so the lookup did not find any permissions and thus the public user (`id` `NULL`) received the deleted user's permissions. Now, the lookup (and deletion) of the permissions is done before the deletion of the user, which avoids this problem.